### PR TITLE
Implement hot page skip for iterative pre-dump

### DIFF
--- a/criu/config.c
+++ b/criu/config.c
@@ -446,6 +446,10 @@ void init_opts(void)
 	opts.async_prefetch = false;
 	opts.prefetch_workers = 4;		/* Default 4 workers */
 	opts.cache_limit_mb = 0;		/* Default unlimited */
+
+	/* Initialize exclude ranges */
+	INIT_LIST_HEAD(&opts.exclude_ranges);
+	INIT_LIST_HEAD(&opts.no_parent_ranges);
 }
 
 bool deprecated_ok(char *what)
@@ -729,6 +733,9 @@ int parse_options(int argc, char **argv, bool *usage_error, bool *has_exec_cmd, 
 		{ "async-prefetch", no_argument, NULL, 1109 },
 		{ "prefetch-workers", required_argument, 0, 1110 },
 		{ "cache-limit", required_argument, 0, 1111 },
+		{ "exclude-range", required_argument, 0, 1112 },
+		{ "exclude-file", required_argument, 0, 1113 },
+		{ "no-parent-range", required_argument, 0, 1114 },
 		{},
 	};
 
@@ -1114,6 +1121,50 @@ int parse_options(int argc, char **argv, bool *usage_error, bool *has_exec_cmd, 
 		case 1111:
 			opts.cache_limit_mb = strtoul(optarg, NULL, 10);
 			break;
+		case 1112: {
+			struct exclude_range *er = xzalloc(sizeof(*er));
+			if (!er)
+				return 1;
+			if (sscanf(optarg, "%lx:%lx", &er->start, &er->end) != 2) {
+				pr_err("Invalid exclude-range format: %s (expected start:end in hex)\n", optarg);
+				xfree(er);
+				return 1;
+			}
+			list_add_tail(&er->list, &opts.exclude_ranges);
+			break;
+		}
+		case 1113: {
+			unsigned long s, e;
+			FILE *f = fopen(optarg, "r");
+			if (!f) {
+				pr_perror("Can't open exclude file %s", optarg);
+				return 1;
+			}
+			while (fscanf(f, "%lx %lx", &s, &e) == 2) {
+				struct exclude_range *er = xzalloc(sizeof(*er));
+				if (!er) {
+					fclose(f);
+					return 1;
+				}
+				er->start = s;
+				er->end = e;
+				list_add_tail(&er->list, &opts.exclude_ranges);
+			}
+			fclose(f);
+			break;
+		}
+		case 1114: {
+			struct exclude_range *er = xzalloc(sizeof(*er));
+			if (!er)
+				return 1;
+			if (sscanf(optarg, "%lx:%lx", &er->start, &er->end) != 2) {
+				pr_err("Invalid no-parent-range format: %s (expected start:end in hex)\n", optarg);
+				xfree(er);
+				return 1;
+			}
+			list_add_tail(&er->list, &opts.no_parent_ranges);
+			break;
+		}
 		default:
 			return 2;
 		}

--- a/criu/include/cr_options.h
+++ b/criu/include/cr_options.h
@@ -130,6 +130,12 @@ enum criu_mode {
 	CR_SHOW_DEPRECATED,
 };
 
+struct exclude_range {
+	unsigned long start;
+	unsigned long end;
+	struct list_head list;
+};
+
 struct cr_options {
 	int final_state;
 	int check_extra_features;
@@ -262,6 +268,11 @@ struct cr_options {
 	bool async_prefetch;
 	int prefetch_workers;
 	unsigned long cache_limit_mb;
+
+	/* Hot VMA exclude ranges for pre-dump */
+	struct list_head exclude_ranges;
+	/* No-parent ranges: dump normally but without parent reference */
+	struct list_head no_parent_ranges;
 };
 
 extern struct cr_options opts;

--- a/criu/mem.c
+++ b/criu/mem.c
@@ -252,6 +252,76 @@ static int generate_iovs(struct pstree_item *item, struct vma_area *vma, struct 
 	return ret;
 }
 
+static bool vma_in_exclude_list(unsigned long vma_start, unsigned long vma_end)
+{
+	struct exclude_range *er;
+
+	if (list_empty(&opts.exclude_ranges))
+		return false;
+
+	list_for_each_entry(er, &opts.exclude_ranges, list) {
+		if (vma_start < er->end && vma_end > er->start)
+			return true;
+	}
+	return false;
+}
+
+static bool vma_in_no_parent_list(unsigned long vma_start, unsigned long vma_end)
+{
+	struct exclude_range *er;
+
+	if (list_empty(&opts.no_parent_ranges))
+		return false;
+
+	list_for_each_entry(er, &opts.no_parent_ranges, list) {
+		if (vma_start < er->end && vma_end > er->start)
+			return true;
+	}
+	return false;
+}
+
+static void save_hot_vma_metadata(const char *imgs_dir)
+{
+	char path[PATH_MAX];
+	struct exclude_range *er;
+	FILE *f;
+	bool first;
+
+	snprintf(path, sizeof(path), "%s/hot-vmas.json", imgs_dir);
+	f = fopen(path, "w");
+	if (!f) {
+		pr_perror("Can't create %s", path);
+		return;
+	}
+
+	fprintf(f, "{\n");
+
+	fprintf(f, "  \"excluded\": [\n");
+	first = true;
+	list_for_each_entry(er, &opts.exclude_ranges, list) {
+		if (!first)
+			fprintf(f, ",\n");
+		fprintf(f, "    {\"start\": \"0x%lx\", \"end\": \"0x%lx\"}", er->start, er->end);
+		first = false;
+	}
+	fprintf(f, "\n  ],\n");
+
+	fprintf(f, "  \"no_parent\": [\n");
+	first = true;
+	list_for_each_entry(er, &opts.no_parent_ranges, list) {
+		if (!first)
+			fprintf(f, ",\n");
+		fprintf(f, "    {\"start\": \"0x%lx\", \"end\": \"0x%lx\"}", er->start, er->end);
+		first = false;
+	}
+	fprintf(f, "\n  ]\n");
+
+	fprintf(f, "}\n");
+	fclose(f);
+
+	pr_info("Saved hot VMA metadata to %s\n", path);
+}
+
 static struct parasite_dump_pages_args *
 prep_dump_pages_args(struct parasite_ctl *ctl, struct vm_area_list *vma_area_list, bool skip_non_trackable)
 {
@@ -278,6 +348,9 @@ prep_dump_pages_args(struct parasite_ctl *ctl, struct vm_area_list *vma_area_lis
 		 * See also generate_vma_iovs() comment.
 		 */
 		if ((vma->e->flags & MAP_HUGETLB) && skip_non_trackable)
+			continue;
+		/* Skip hot VMAs during pre-dump */
+		if (skip_non_trackable && vma_in_exclude_list(vma->e->start, vma->e->start + vma_area_len(vma)))
 			continue;
 		if (vma->e->prot & PROT_READ)
 			continue;
@@ -456,6 +529,23 @@ static int generate_vma_iovs(struct pstree_item *item, struct vma_area *vma, str
 		has_parent = false;
 	}
 
+	/* Hot VMA handling: skip during pre-dump, full dump without parent on final dump */
+	if (vma_in_exclude_list(vma->e->start, vma->e->end)) {
+		if (pre_dump) {
+			pr_info("Skipping hot VMA [%lx-%lx] during pre-dump\n",
+				(unsigned long)vma->e->start, (unsigned long)vma->e->end);
+			return 0;
+		}
+		has_parent = false;
+	}
+
+	/* No-parent VMA: dump normally but without parent reference */
+	if (vma_in_no_parent_list(vma->e->start, vma->e->end)) {
+		pr_info("No-parent VMA [%lx-%lx]: dumping without parent reference\n",
+			(unsigned long)vma->e->start, (unsigned long)vma->e->end);
+		has_parent = false;
+	}
+
 	if (pmc_get_map(pmc, vma))
 		return -1;
 
@@ -590,6 +680,10 @@ static int __parasite_dump_pages_seized(struct pstree_item *item, struct parasit
 	ret = task_reset_dirty_track(item->pid->real);
 	if (ret)
 		goto out_xfer;
+
+	if (!list_empty(&opts.exclude_ranges) || !list_empty(&opts.no_parent_ranges))
+		save_hot_vma_metadata(opts.imgs_dir);
+
 	exit_code = 0;
 out_xfer:
 	if (!mdc->pre_dump)


### PR DESCRIPTION
## Summary
- Pre-dump 시 hot VMA를 선택적으로 skip하여 I/O를 최소화하는 `--exclude-range`, `--exclude-file` 옵션 추가
- Hot→cold VMA 전환 시 parent image 참조 정합성을 유지하는 `--no-parent-range` 옵션 추가
- Dump image directory에 `hot-vmas.json` metadata sidecar 파일 자동 생성

## 변경 내용

### CLI 옵션 (3개)
| 옵션 | 번호 | 동작 |
|------|------|------|
| `--exclude-range start:end` | 1112 | Pre-dump: VMA skip, Final dump: has_parent=false |
| `--exclude-file filepath` | 1113 | 파일에서 exclude range 목록 읽기 |
| `--no-parent-range start:end` | 1114 | Skip 없이 dump하되 has_parent=false (hot→cold 전환용) |

### 수정 파일 (3개, +156 LoC)
- `criu/include/cr_options.h`: `struct exclude_range`, `exclude_ranges`/`no_parent_ranges` 필드
- `criu/config.c`: 옵션 등록, 파싱, 초기화
- `criu/mem.c`: `vma_in_exclude_list()`, `vma_in_no_parent_list()`, `generate_vma_iovs()` skip 로직, `prep_dump_pages_args()` skip, `save_hot_vma_metadata()`

## 검증 결과

### --exclude-range 기본 동작
- Pre-dump I/O 감소: 261MB → 0.07MB (99.97% 감소)
- 부분 exclude (3개 64MB region 중 1개/2개 선택적 skip): 정확히 64MB 단위로 감소
- Final dump: excluded VMA를 has_parent=false로 full dump 성공

### --no-parent-range: hot→cold 전환 (5 region × 6 iterations)
```
Region:  A      B      C      D      E
PD1:     excl   excl   excl   dump   dump    → 64MB
PD2:     excl   excl   no-par dump*  dump*   → 32MB
PD3:     excl   no-par dump*  excl   dump*   → 32MB
PD4:     excl   dump*  excl   excl   dump*   → 0MB
PD5:     excl   dump*  no-par no-par dump*   → 64MB
PD6:     excl   excl   dump*  dump*  dump*   → 0MB
Final:   excl   excl   dump*  dump*  dump*   → 64MB
ALL 7 TESTS PASSED
```

### Restore 검증
- 3개 region에 각각 고유 패턴(0xAA, 0xBB, 0xCC) 기록
- exclude→no-parent→parent chain을 거친 후 restore
- SIGUSR1로 메모리 무결성 검증: **모든 region 패턴 정확히 일치 (VERIFY_OK)**

## Test plan
- [x] `make -j$(nproc)` 빌드 성공
- [x] `--exclude-range` 기본 동작 (pre-dump skip + final dump full dump)
- [x] 부분 exclude (일부 VMA만 skip)
- [x] `--no-parent-range` hot→cold 전환 시나리오
- [x] 복합 전환 (hot→cold→hot→cold 사이클, 동시 다중 전환)
- [x] 6단계 pre-dump chain 정합성
- [x] Restore 후 메모리 무결성 검증
- [x] `hot-vmas.json` metadata 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)