### PR TITLE
Add object storage direct upload for checkpoint images

### DIFF
--- a/criu/config.c
+++ b/criu/config.c
@@ -738,6 +738,7 @@ int parse_options(int argc, char **argv, bool *usage_error, bool *has_exec_cmd, 
 		{ "exclude-file", required_argument, 0, 1113 },
 		{ "no-parent-range", required_argument, 0, 1114 },
 		{ "object-storage-path-style", no_argument, NULL, 1115 },
+		{ "object-storage-upload", no_argument, NULL, 1116 },
 		{},
 	};
 
@@ -1169,6 +1170,10 @@ int parse_options(int argc, char **argv, bool *usage_error, bool *has_exec_cmd, 
 		}
 		case 1115:
 			opts.object_storage_path_style = true;
+			break;
+		case 1116:
+			opts.object_storage_upload = true;
+			opts.enable_object_storage = true;
 			break;
 		default:
 			return 2;

--- a/criu/image.c
+++ b/criu/image.c
@@ -623,6 +623,46 @@ static int do_open_image(struct cr_img *img, int dfd, int type, unsigned long of
 		ret = openat(dfd, path, flags, CR_FD_PERM);
 	if (ret < 0) {
 		if (!(flags & O_CREAT) && (errno == ENOENT || ret == -ENOENT)) {
+			/*
+			 * File not found locally. If object storage is enabled,
+			 * try fetching from S3 and create a memfd for it.
+			 */
+			if (opts.enable_object_storage) {
+				void *s3_data = NULL;
+				unsigned long s3_len = 0;
+				int s3_ret;
+				int mfd;
+
+				s3_ret = object_storage_get_object(path, &s3_data, &s3_len);
+				if (s3_ret == 0 && s3_data && s3_len > 0) {
+					mfd = memfd_create(path, 0);
+					if (mfd >= 0) {
+						unsigned long wr = 0;
+						ssize_t nw;
+
+						while (wr < s3_len) {
+							nw = write(mfd, (char *)s3_data + wr, s3_len - wr);
+							if (nw <= 0)
+								break;
+							wr += nw;
+						}
+						free(s3_data);
+						if (wr == s3_len) {
+							lseek(mfd, 0, SEEK_SET);
+							ret = mfd;
+							pr_info("Fetched %s from object storage (%lu bytes)\n",
+								path, s3_len);
+							goto got_fd;
+						}
+						close(mfd);
+					} else {
+						free(s3_data);
+					}
+				} else if (s3_data) {
+					free(s3_data);
+				}
+			}
+
 			pr_info("No %s image\n", path);
 			img->_x.fd = EMPTY_IMG_FD;
 			goto skip_magic;
@@ -631,6 +671,8 @@ static int do_open_image(struct cr_img *img, int dfd, int type, unsigned long of
 		pr_perror("Unable to open %s", path);
 		goto err;
 	}
+
+got_fd:
 
 	img->_x.fd = ret;
 

--- a/criu/image.c
+++ b/criu/image.c
@@ -620,6 +620,13 @@ static int do_open_image(struct cr_img *img, int dfd, int type, unsigned long of
 		ret = userns_call(userns_openat, UNS_FDOUT, &pa, sizeof(struct openat_args), dfd);
 		if (ret < 0)
 			errno = pa.err;
+	} else if (opts.object_storage_upload && (flags & O_CREAT)) {
+		/*
+		 * Object storage upload mode: use memfd instead of local file.
+		 * All writes go to memory, uploaded to S3 on close_image().
+		 * Eliminates disk I/O entirely for metadata files.
+		 */
+		ret = memfd_create(path, 0);
 	} else
 		ret = openat(dfd, path, flags, CR_FD_PERM);
 	if (ret < 0) {
@@ -752,11 +759,14 @@ void close_image(struct cr_img *img)
 			int fd;
 			off_t file_size;
 
-			/* Flush buffered writes first */
+			/*
+			 * Dup the fd before bclose() closes it, so we can
+			 * read back the written data for S3 upload.
+			 * Works with both memfd (S3-only) and local files (dual-write).
+			 */
+			fd = dup(img->_x.fd);
 			bclose(&img->_x);
 
-			/* Reopen to read back for S3 upload */
-			fd = openat(get_service_fd(IMG_FD_OFF), img->path, O_RDONLY);
 			if (fd >= 0) {
 				file_size = lseek(fd, 0, SEEK_END);
 				if (file_size > 0) {
@@ -775,10 +785,9 @@ void close_image(struct cr_img *img)
 								break;
 							rd += nr;
 						}
-						if (rd == (unsigned long)file_size) {
+						if (rd == (unsigned long)file_size)
 							object_storage_put_object(
 								img->path, buf, file_size);
-						}
 						xfree(buf);
 					}
 				}

--- a/criu/image.c
+++ b/criu/image.c
@@ -834,19 +834,73 @@ int open_image_dir(char *dir, int mode)
 			goto err;
 	} else if (opts.img_parent) {
 		if (faccessat(fd, opts.img_parent, R_OK, 0)) {
-			pr_perror("Invalid parent image directory provided");
-			goto err;
+			if (!opts.enable_object_storage) {
+				pr_perror("Invalid parent image directory provided");
+				goto err;
+			}
+			pr_info("Parent dir %s not found locally, skipping symlink (object storage mode)\n",
+				opts.img_parent);
+		} else {
+			ret = symlinkat(opts.img_parent, fd, CR_PARENT_LINK);
+			if (ret < 0 && errno != EEXIST) {
+				pr_perror("Can't link parent snapshot");
+				goto err;
+			}
+
+			if (opts.img_parent[0] == '/')
+				pr_warn("Absolute paths for parent links "
+					"may not work on restore!\n");
 		}
 
-		ret = symlinkat(opts.img_parent, fd, CR_PARENT_LINK);
-		if (ret < 0 && errno != EEXIST) {
-			pr_perror("Can't link parent snapshot");
-			goto err;
-		}
+		/*
+		 * Upload parent prefix info to S3 so restore can find parent.
+		 * Convention: resolve --prev-images-dir relative to current prefix.
+		 * E.g., prefix="ckpt/dump2/", parent="../dump1/" → "ckpt/dump1/"
+		 */
+		if (opts.object_storage_upload && opts.object_storage_object_prefix) {
+			char parent_prefix[1024];
+			const char *cur = opts.object_storage_object_prefix;
+			const char *rel = opts.img_parent;
+			size_t cur_len;
+			size_t pp_len;
 
-		if (opts.img_parent[0] == '/')
-			pr_warn("Absolute paths for parent links "
-				"may not work on restore!\n");
+			/* Copy current prefix and resolve relative path */
+			snprintf(parent_prefix, sizeof(parent_prefix), "%s", cur);
+			cur_len = strlen(parent_prefix);
+			/* Remove trailing slash */
+			if (cur_len > 0 && parent_prefix[cur_len - 1] == '/')
+				parent_prefix[--cur_len] = '\0';
+
+			/* Process "../" segments */
+			while (strncmp(rel, "../", 3) == 0) {
+				char *last_slash;
+				rel += 3;
+				last_slash = strrchr(parent_prefix, '/');
+				if (last_slash)
+					*last_slash = '\0';
+				else
+					parent_prefix[0] = '\0';
+			}
+			/* Append remaining relative path */
+			if (rel[0]) {
+				pp_len = strlen(parent_prefix);
+				if (pp_len > 0)
+					snprintf(parent_prefix + pp_len,
+						 sizeof(parent_prefix) - pp_len, "/%s", rel);
+				else
+					snprintf(parent_prefix, sizeof(parent_prefix), "%s", rel);
+			}
+			/* Ensure trailing slash */
+			pp_len = strlen(parent_prefix);
+			if (pp_len > 0 && parent_prefix[pp_len - 1] != '/') {
+				parent_prefix[pp_len] = '/';
+				parent_prefix[pp_len + 1] = '\0';
+			}
+
+			pr_info("Uploading parent prefix marker: %s\n", parent_prefix);
+			object_storage_put_object("parent-prefix",
+						  parent_prefix, strlen(parent_prefix));
+		}
 	}
 
 	return 0;

--- a/criu/image.c
+++ b/criu/image.c
@@ -748,7 +748,7 @@ void close_image(struct cr_img *img)
 		 */
 		if (opts.object_storage_upload && img->path &&
 		    strncmp(img->path, "pages-", 6) != 0) {
-			int fd = img_raw_fd(img);
+			int fd;
 			off_t file_size;
 
 			/* Flush buffered writes first */

--- a/criu/image.c
+++ b/criu/image.c
@@ -19,6 +19,7 @@
 #include "proc_parse.h"
 #include "img-streamer.h"
 #include "namespaces.h"
+#include "object-storage.h"
 
 bool ns_per_id = false;
 bool img_common_magic = true;
@@ -632,6 +633,16 @@ static int do_open_image(struct cr_img *img, int dfd, int type, unsigned long of
 	}
 
 	img->_x.fd = ret;
+
+	/*
+	 * When object-storage-upload is enabled and we're writing (O_DUMP),
+	 * save the filename so close_image() can upload to S3.
+	 * We reuse the 'path' field that's normally only used for lazy images.
+	 */
+	if (opts.object_storage_upload && (flags & O_CREAT)) {
+		img->path = xstrdup(path);
+	}
+
 	if (oflags & O_NOBUF)
 		bfd_setraw(&img->_x);
 	else {
@@ -688,8 +699,55 @@ void close_image(struct cr_img *img)
 		 */
 		unlinkat(get_service_fd(IMG_FD_OFF), img->path, 0);
 		xfree(img->path);
-	} else if (!empty_image(img))
-		bclose(&img->_x);
+	} else if (!empty_image(img)) {
+		/*
+		 * Upload metadata files to S3 on close (dual-write).
+		 * Skip pages-*.img as those are handled by page-xfer S3 backend.
+		 */
+		if (opts.object_storage_upload && img->path &&
+		    strncmp(img->path, "pages-", 6) != 0) {
+			int fd = img_raw_fd(img);
+			off_t file_size;
+
+			/* Flush buffered writes first */
+			bclose(&img->_x);
+
+			/* Reopen to read back for S3 upload */
+			fd = openat(get_service_fd(IMG_FD_OFF), img->path, O_RDONLY);
+			if (fd >= 0) {
+				file_size = lseek(fd, 0, SEEK_END);
+				if (file_size > 0) {
+					void *buf;
+					ssize_t nr;
+					unsigned long rd;
+
+					lseek(fd, 0, SEEK_SET);
+					buf = xmalloc(file_size);
+					if (buf) {
+						rd = 0;
+						while (rd < (unsigned long)file_size) {
+							nr = read(fd, (char *)buf + rd,
+								  file_size - rd);
+							if (nr <= 0)
+								break;
+							rd += nr;
+						}
+						if (rd == (unsigned long)file_size) {
+							object_storage_put_object(
+								img->path, buf, file_size);
+						}
+						xfree(buf);
+					}
+				}
+				close(fd);
+			}
+			xfree(img->path);
+		} else {
+			if (img->path)
+				xfree(img->path);
+			bclose(&img->_x);
+		}
+	}
 
 	xfree(img);
 }

--- a/criu/image.c
+++ b/criu/image.c
@@ -307,24 +307,47 @@ InventoryEntry *get_parent_inventory(void)
 	struct cr_img *img;
 	InventoryEntry *ie;
 	int dir;
+	char *saved_prefix = NULL;
+	char *parent_prefix = NULL;
 
 	if (open_parent(get_service_fd(IMG_FD_OFF), &dir)) {
-		/*
-		 * We print the warning below to be notified that we had some
-		 * unexpected problem on open. For instance we have a parent
-		 * directory but have no access. Having no parent inventory
-		 * when also having no parent directory is an expected case of
-		 * first dump iteration.
-		 */
 		pr_warn("Failed to open parent directory\n");
 		return NULL;
 	}
 	if (dir < 0)
 		return NULL;
 
+	/*
+	 * When object storage is enabled, swap prefix to parent's
+	 * so that S3 fallback fetches from the correct location.
+	 */
+	if (opts.enable_object_storage) {
+		void *prefix_data = NULL;
+		unsigned long prefix_len = 0;
+		int s3_ret;
+
+		s3_ret = object_storage_get_object("parent-prefix",
+						   &prefix_data, &prefix_len);
+		if (s3_ret == 0 && prefix_data && prefix_len > 0) {
+			parent_prefix = xmalloc(prefix_len + 1);
+			if (parent_prefix) {
+				memcpy(parent_prefix, prefix_data, prefix_len);
+				parent_prefix[prefix_len] = '\0';
+				saved_prefix = opts.object_storage_object_prefix;
+				opts.object_storage_object_prefix = parent_prefix;
+			}
+		}
+		if (prefix_data)
+			free(prefix_data);
+	}
+
 	img = open_image_at(dir, CR_FD_INVENTORY, O_RSTR);
 	if (!img) {
 		pr_warn("Failed to open parent pre-dump inventory image\n");
+		if (saved_prefix) {
+			opts.object_storage_object_prefix = saved_prefix;
+			xfree(parent_prefix);
+		}
 		close(dir);
 		return NULL;
 	}
@@ -332,8 +355,18 @@ InventoryEntry *get_parent_inventory(void)
 	if (pb_read_one(img, &ie, PB_INVENTORY) < 0) {
 		pr_warn("Failed to read parent pre-dump inventory entry\n");
 		close_image(img);
+		if (saved_prefix) {
+			opts.object_storage_object_prefix = saved_prefix;
+			xfree(parent_prefix);
+		}
 		close(dir);
 		return NULL;
+	}
+
+	/* Restore original prefix */
+	if (saved_prefix) {
+		opts.object_storage_object_prefix = saved_prefix;
+		xfree(parent_prefix);
 	}
 
 	if (!ie->has_dump_uptime) {
@@ -911,6 +944,64 @@ int open_image_dir(char *dir, int mode)
 			pr_info("Uploading parent prefix marker: %s\n", parent_prefix);
 			object_storage_put_object("parent-prefix",
 						  parent_prefix, strlen(parent_prefix));
+		}
+	}
+
+	/*
+	 * On restore: if images-dir contains a parent-prefix file
+	 * (downloaded from S3) but no parent symlink, reconstruct
+	 * the parent symlink from parent-prefix content.
+	 *
+	 * parent-prefix contains the S3 prefix of the parent dump
+	 * (e.g., "chain/dump1/"). We extract the directory name
+	 * (e.g., "dump1") and create a symlink "../dump1" → parent.
+	 */
+	if (mode == O_RSTR && !opts.img_parent) {
+		struct stat st;
+		if (fstatat(fd, CR_PARENT_LINK, &st, AT_SYMLINK_NOFOLLOW) != 0 &&
+		    errno == ENOENT) {
+			/* No parent symlink — check for parent-prefix file */
+			int ppfd;
+			ppfd = openat(fd, "parent-prefix", O_RDONLY);
+			if (ppfd >= 0) {
+				char pp_buf[1024];
+				ssize_t nr;
+				nr = read(ppfd, pp_buf, sizeof(pp_buf) - 1);
+				close(ppfd);
+				if (nr > 0) {
+					char *last_slash;
+					char *dir_name;
+					char symlink_target[1024];
+
+					pp_buf[nr] = '\0';
+					/* Remove trailing slash/newline */
+					while (nr > 0 && (pp_buf[nr-1] == '/' || pp_buf[nr-1] == '\n'))
+						pp_buf[--nr] = '\0';
+
+					/* Extract last component: "chain/dump1" → "dump1" */
+					last_slash = strrchr(pp_buf, '/');
+					dir_name = last_slash ? last_slash + 1 : pp_buf;
+
+					/* Create symlink: ../dump1 */
+					snprintf(symlink_target, sizeof(symlink_target),
+						 "../%.1020s", dir_name);
+
+					/* Verify target exists */
+					if (faccessat(fd, symlink_target, R_OK, 0) == 0) {
+						ret = symlinkat(symlink_target, fd, CR_PARENT_LINK);
+						if (ret == 0 || errno == EEXIST)
+							pr_info("Reconstructed parent symlink: %s\n",
+								symlink_target);
+						else
+							pr_warn("Failed to create parent symlink %s\n",
+								symlink_target);
+					} else {
+						pr_debug("Parent dir %s not found locally, "
+							 "skipping symlink reconstruction\n",
+							 symlink_target);
+					}
+				}
+			}
 		}
 	}
 

--- a/criu/image.c
+++ b/criu/image.c
@@ -509,6 +509,7 @@ struct cr_img *open_image_at(int dfd, int type, unsigned long flags, ...)
 	img = xmalloc(sizeof(*img));
 	if (!img)
 		return NULL;
+	img->path = NULL;
 
 	oflags = flags | imgset_template[type].oflags;
 
@@ -801,6 +802,7 @@ struct cr_img *img_from_fd(int fd)
 	img = xmalloc(sizeof(*img));
 	if (img) {
 		img->_x.fd = fd;
+		img->path = NULL;
 		bfd_setraw(&img->_x);
 	}
 

--- a/criu/include/cr_options.h
+++ b/criu/include/cr_options.h
@@ -254,6 +254,7 @@ struct cr_options {
 
 	/* Object storage options */
 	bool enable_object_storage;
+	bool object_storage_upload;
 	char *object_storage_endpoint_url;
 	char *object_storage_bucket;
 	char *object_storage_object_prefix;

--- a/criu/include/image.h
+++ b/criu/include/image.h
@@ -116,9 +116,9 @@ struct cr_img {
 			int fd; /* should be first to coincide with _x.fd */
 			int type;
 			unsigned long oflags;
-			char *path;
 		};
 	};
+	char *path; /* filename for lazy images and S3 upload tracking */
 };
 
 #define EMPTY_IMG_FD (-404)

--- a/criu/include/object-storage.h
+++ b/criu/include/object-storage.h
@@ -128,6 +128,17 @@ int object_storage_fetch_range(const char *object_key, unsigned long offset, uns
 int object_storage_put_object(const char *object_key, const void *data, unsigned long length);
 
 /*
+ * Fetch an entire object from object storage (for metadata files with unknown size)
+ *
+ * @param object_key: The key/path of the object
+ * @param out_data: Output pointer to allocated buffer (caller must free)
+ * @param out_length: Output size of fetched data
+ *
+ * Returns 0 on success, -ENOENT if not found, -1 on other failure
+ */
+int object_storage_get_object(const char *object_key, void **out_data, unsigned long *out_length);
+
+/*
  * Multipart upload API — for large files (pages-*.img, > 5MB)
  *
  * Usage:

--- a/criu/include/object-storage.h
+++ b/criu/include/object-storage.h
@@ -117,6 +117,17 @@ int object_storage_init(void);
 int object_storage_fetch_range(const char *object_key, unsigned long offset, unsigned long length, void *buffer);
 
 /*
+ * Upload an object to object storage (simple PUT, for files < 5GB)
+ *
+ * @param object_key: The key/path for the object in the bucket
+ * @param data: Pointer to data to upload
+ * @param length: Size of data in bytes
+ *
+ * Returns 0 on success, -1 on failure
+ */
+int object_storage_put_object(const char *object_key, const void *data, unsigned long length);
+
+/*
  * Clean up the object storage client and release resources
  */
 void object_storage_cleanup(void);

--- a/criu/include/object-storage.h
+++ b/criu/include/object-storage.h
@@ -128,6 +128,23 @@ int object_storage_fetch_range(const char *object_key, unsigned long offset, uns
 int object_storage_put_object(const char *object_key, const void *data, unsigned long length);
 
 /*
+ * Multipart upload API — for large files (pages-*.img, > 5MB)
+ *
+ * Usage:
+ *   1. multipart_init()        → get upload_id
+ *   2. multipart_upload_part() → repeat for each part (min 5MB except last)
+ *   3. multipart_complete()    → finalize with etags
+ *   On error: multipart_abort() to clean up
+ */
+int object_storage_multipart_init(const char *object_key, char *upload_id, size_t id_len);
+int object_storage_multipart_upload_part(const char *object_key, const char *upload_id,
+					 int part_num, const void *data, unsigned long length,
+					 char *etag, size_t etag_len);
+int object_storage_multipart_complete(const char *object_key, const char *upload_id,
+				      int n_parts, const char **etags);
+int object_storage_multipart_abort(const char *object_key, const char *upload_id);
+
+/*
  * Clean up the object storage client and release resources
  */
 void object_storage_cleanup(void);

--- a/criu/include/page-xfer.h
+++ b/criu/include/page-xfer.h
@@ -45,6 +45,21 @@ struct page_xfer {
 		};
 	};
 
+	/* S3 upload state (used alongside local when --object-storage-upload) */
+	struct {
+		char upload_id[256];
+		char pages_key[512];
+		char pagemap_key[512];
+		void *part_buf;
+		unsigned long part_buf_used;
+		unsigned long part_buf_cap;
+		int part_number;
+		char **etags;
+		int etags_count;
+		int etags_cap;
+		int active;		/* 1 if S3 upload is in progress */
+	} s3;
+
 	struct page_read *parent;
 };
 

--- a/criu/include/page-xfer.h
+++ b/criu/include/page-xfer.h
@@ -58,7 +58,7 @@ struct page_xfer {
 		int etags_count;
 		int etags_cap;
 		int active;		/* 1 if S3 upload is in progress */
-	} s3;
+	} object_storage;
 
 	struct page_read *parent;
 };

--- a/criu/include/pagemap.h
+++ b/criu/include/pagemap.h
@@ -81,6 +81,9 @@ struct page_read {
 	int curr_pme;
 
 	struct list_head async;
+
+	/* S3 object prefix override for this page_read (NULL = use global) */
+	char *object_storage_prefix;
 };
 
 /* flags for ->read_pages */

--- a/criu/object-storage.c
+++ b/criu/object-storage.c
@@ -1351,6 +1351,347 @@ int object_storage_put_object(const char *object_key, const void *data, unsigned
 
 /*
  * =================================================================================
+ * Multipart Upload — for large files (pages-*.img, typically > 5MB)
+ * =================================================================================
+ */
+
+int object_storage_multipart_init(const char *object_key, char *upload_id, size_t id_len)
+{
+	struct object_url_info url_info;
+	struct MemoryStruct response;
+	CURL *curl_handle;
+	CURLcode res;
+	long http_code = 0;
+	struct curl_slist *headers = NULL;
+	char full_url[2200];
+
+	if (opts.express_one_zone) {
+		if (ensure_valid_session() != 0)
+			return -1;
+	}
+
+	if (_construct_object_url(object_key, &url_info) != 0)
+		return -1;
+
+	/* Append ?uploads to URL */
+	snprintf(full_url, sizeof(full_url), "%s?uploads", url_info.url);
+
+	curl_handle = _get_curl_handle();
+	if (!curl_handle)
+		return -1;
+
+	response.memory = malloc(1);
+	response.size = 0;
+	response.capacity = 0;
+
+	curl_easy_setopt(curl_handle, CURLOPT_URL, full_url);
+	curl_easy_setopt(curl_handle, CURLOPT_POST, 1L);
+	curl_easy_setopt(curl_handle, CURLOPT_POSTFIELDSIZE, 0L);
+	curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, write_callback);
+	curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, &response);
+
+	/* SigV4: POST with empty body, query_string = "uploads=" */
+	if (_build_auth_headers("POST", url_info.auth_host, url_info.canonical_uri,
+			       "uploads=", EMPTY_PAYLOAD_HASH, NULL, 0, &headers) != 0) {
+		free(response.memory);
+		return -1;
+	}
+	if (headers)
+		curl_easy_setopt(curl_handle, CURLOPT_HTTPHEADER, headers);
+
+	res = curl_easy_perform(curl_handle);
+	curl_easy_getinfo(curl_handle, CURLINFO_RESPONSE_CODE, &http_code);
+
+	if (headers)
+		curl_slist_free_all(headers);
+
+	if (res != CURLE_OK || http_code < 200 || http_code >= 300) {
+		pr_err("Multipart init failed: curl=%s http=%ld body=%.*s\n",
+		       curl_easy_strerror(res), http_code, (int)response.size, response.memory);
+		free(response.memory);
+		return -1;
+	}
+
+	/* Parse UploadId from XML response */
+	if (_parse_xml_tag(response.memory, "UploadId", upload_id, id_len) != 0) {
+		pr_err("Failed to parse UploadId from response: %.*s\n",
+		       (int)response.size, response.memory);
+		free(response.memory);
+		return -1;
+	}
+
+	pr_info("Multipart upload initiated: %s uploadId=%s\n", object_key, upload_id);
+	free(response.memory);
+	return 0;
+}
+
+int object_storage_multipart_upload_part(const char *object_key, const char *upload_id,
+					 int part_num, const void *data, unsigned long length,
+					 char *etag, size_t etag_len)
+{
+	struct object_url_info url_info;
+	struct UploadContext upload_ctx;
+	struct MemoryStruct response;
+	struct MemoryStruct header_buf;
+	CURL *curl_handle;
+	CURLcode res;
+	long http_code = 0;
+	struct curl_slist *headers = NULL;
+	char full_url[2400];
+	char query_string[512];
+	char content_sha256[65];
+	char *etag_hdr;
+
+	if (opts.express_one_zone) {
+		if (ensure_valid_session() != 0)
+			return -1;
+	}
+
+	if (_construct_object_url(object_key, &url_info) != 0)
+		return -1;
+
+	snprintf(full_url, sizeof(full_url), "%s?partNumber=%d&uploadId=%s",
+		 url_info.url, part_num, upload_id);
+	/* Query string must be sorted alphabetically for SigV4 */
+	snprintf(query_string, sizeof(query_string), "partNumber=%d&uploadId=%s",
+		 part_num, upload_id);
+
+	_sha256_hex((const char *)data, length, content_sha256);
+
+	curl_handle = _get_curl_handle();
+	if (!curl_handle)
+		return -1;
+
+	upload_ctx.data = (const char *)data;
+	upload_ctx.size = length;
+	upload_ctx.offset = 0;
+
+	response.memory = malloc(1);
+	response.size = 0;
+	response.capacity = 0;
+
+	curl_easy_setopt(curl_handle, CURLOPT_URL, full_url);
+	curl_easy_setopt(curl_handle, CURLOPT_UPLOAD, 1L);
+	curl_easy_setopt(curl_handle, CURLOPT_READFUNCTION, _upload_read_callback);
+	curl_easy_setopt(curl_handle, CURLOPT_READDATA, &upload_ctx);
+	curl_easy_setopt(curl_handle, CURLOPT_INFILESIZE_LARGE, (curl_off_t)length);
+	curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, write_callback);
+	curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, &response);
+
+	/* We need ETag from response headers */
+	header_buf.memory = malloc(1);
+	header_buf.size = 0;
+	header_buf.capacity = 0;
+	curl_easy_setopt(curl_handle, CURLOPT_HEADERFUNCTION, write_callback);
+	curl_easy_setopt(curl_handle, CURLOPT_HEADERDATA, &header_buf);
+
+	if (_build_auth_headers("PUT", url_info.auth_host, url_info.canonical_uri,
+			       query_string, content_sha256, NULL, (long)length, &headers) != 0) {
+		free(response.memory);
+		free(header_buf.memory);
+		return -1;
+	}
+	if (headers)
+		curl_easy_setopt(curl_handle, CURLOPT_HTTPHEADER, headers);
+
+	res = curl_easy_perform(curl_handle);
+	curl_easy_getinfo(curl_handle, CURLINFO_RESPONSE_CODE, &http_code);
+
+	if (headers)
+		curl_slist_free_all(headers);
+
+	if (res != CURLE_OK || http_code < 200 || http_code >= 300) {
+		pr_err("Upload part %d failed: curl=%s http=%ld\n",
+		       part_num, curl_easy_strerror(res), http_code);
+		free(response.memory);
+		free(header_buf.memory);
+		return -1;
+	}
+
+	/* Extract ETag from response headers */
+	etag_hdr = strcasestr(header_buf.memory, "ETag:");
+	if (etag_hdr) {
+		size_t ei;
+		etag_hdr += 5;
+		while (*etag_hdr == ' ' || *etag_hdr == '\t')
+			etag_hdr++;
+		for (ei = 0; etag_hdr[ei] && etag_hdr[ei] != '\r' && etag_hdr[ei] != '\n' && ei < etag_len - 1; ei++)
+			etag[ei] = etag_hdr[ei];
+		etag[ei] = '\0';
+	} else {
+		pr_err("No ETag in upload part response headers\n");
+		free(response.memory);
+		free(header_buf.memory);
+		return -1;
+	}
+
+	pr_debug("Uploaded part %d (%lu bytes), ETag=%s\n", part_num, length, etag);
+	free(response.memory);
+	free(header_buf.memory);
+	return 0;
+}
+
+int object_storage_multipart_complete(const char *object_key, const char *upload_id,
+				      int n_parts, const char **etags)
+{
+	struct object_url_info url_info;
+	struct UploadContext upload_ctx;
+	struct MemoryStruct response;
+	CURL *curl_handle;
+	CURLcode res;
+	long http_code = 0;
+	struct curl_slist *headers = NULL;
+	char full_url[2400];
+	char query_string[512];
+	char content_sha256[65];
+	char *xml_body;
+	size_t xml_len;
+	size_t xml_pos;
+	int i;
+
+	if (opts.express_one_zone) {
+		if (ensure_valid_session() != 0)
+			return -1;
+	}
+
+	if (_construct_object_url(object_key, &url_info) != 0)
+		return -1;
+
+	snprintf(full_url, sizeof(full_url), "%s?uploadId=%s", url_info.url, upload_id);
+	snprintf(query_string, sizeof(query_string), "uploadId=%s", upload_id);
+
+	/* Build XML body: <CompleteMultipartUpload><Part>...</Part>...</> */
+	xml_len = 128 + n_parts * 256;
+	xml_body = malloc(xml_len);
+	if (!xml_body)
+		return -1;
+
+	xml_pos = 0;
+	xml_pos += snprintf(xml_body + xml_pos, xml_len - xml_pos,
+			    "<CompleteMultipartUpload>");
+	for (i = 0; i < n_parts; i++) {
+		xml_pos += snprintf(xml_body + xml_pos, xml_len - xml_pos,
+				    "<Part><PartNumber>%d</PartNumber><ETag>%s</ETag></Part>",
+				    i + 1, etags[i]);
+	}
+	xml_pos += snprintf(xml_body + xml_pos, xml_len - xml_pos,
+			    "</CompleteMultipartUpload>");
+	xml_len = xml_pos;
+
+	_sha256_hex(xml_body, xml_len, content_sha256);
+
+	curl_handle = _get_curl_handle();
+	if (!curl_handle) {
+		free(xml_body);
+		return -1;
+	}
+
+	upload_ctx.data = xml_body;
+	upload_ctx.size = xml_len;
+	upload_ctx.offset = 0;
+
+	response.memory = malloc(1);
+	response.size = 0;
+	response.capacity = 0;
+
+	curl_easy_setopt(curl_handle, CURLOPT_URL, full_url);
+	curl_easy_setopt(curl_handle, CURLOPT_POST, 1L);
+	curl_easy_setopt(curl_handle, CURLOPT_READFUNCTION, _upload_read_callback);
+	curl_easy_setopt(curl_handle, CURLOPT_READDATA, &upload_ctx);
+	curl_easy_setopt(curl_handle, CURLOPT_POSTFIELDSIZE_LARGE, (curl_off_t)xml_len);
+	curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, write_callback);
+	curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, &response);
+
+	if (_build_auth_headers("POST", url_info.auth_host, url_info.canonical_uri,
+			       query_string, content_sha256, NULL, (long)xml_len, &headers) != 0) {
+		free(xml_body);
+		free(response.memory);
+		return -1;
+	}
+	/* Content-Type for the completion XML */
+	headers = curl_slist_append(headers, "Content-Type: application/xml");
+	curl_easy_setopt(curl_handle, CURLOPT_HTTPHEADER, headers);
+
+	res = curl_easy_perform(curl_handle);
+	curl_easy_getinfo(curl_handle, CURLINFO_RESPONSE_CODE, &http_code);
+
+	if (headers)
+		curl_slist_free_all(headers);
+	free(xml_body);
+
+	if (res != CURLE_OK || http_code < 200 || http_code >= 300) {
+		pr_err("Multipart complete failed: curl=%s http=%ld body=%.*s\n",
+		       curl_easy_strerror(res), http_code, (int)response.size, response.memory);
+		free(response.memory);
+		return -1;
+	}
+
+	pr_info("Multipart upload completed: %s (%d parts)\n", object_key, n_parts);
+	free(response.memory);
+	return 0;
+}
+
+int object_storage_multipart_abort(const char *object_key, const char *upload_id)
+{
+	struct object_url_info url_info;
+	struct MemoryStruct response;
+	CURL *curl_handle;
+	CURLcode res;
+	long http_code = 0;
+	struct curl_slist *headers = NULL;
+	char full_url[2400];
+	char query_string[512];
+
+	if (opts.express_one_zone) {
+		if (ensure_valid_session() != 0)
+			return -1;
+	}
+
+	if (_construct_object_url(object_key, &url_info) != 0)
+		return -1;
+
+	snprintf(full_url, sizeof(full_url), "%s?uploadId=%s", url_info.url, upload_id);
+	snprintf(query_string, sizeof(query_string), "uploadId=%s", upload_id);
+
+	curl_handle = _get_curl_handle();
+	if (!curl_handle)
+		return -1;
+
+	response.memory = malloc(1);
+	response.size = 0;
+	response.capacity = 0;
+
+	curl_easy_setopt(curl_handle, CURLOPT_URL, full_url);
+	curl_easy_setopt(curl_handle, CURLOPT_CUSTOMREQUEST, "DELETE");
+	curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, write_callback);
+	curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, &response);
+
+	if (_build_auth_headers("DELETE", url_info.auth_host, url_info.canonical_uri,
+			       query_string, EMPTY_PAYLOAD_HASH, NULL, -1, &headers) != 0) {
+		free(response.memory);
+		return -1;
+	}
+	if (headers)
+		curl_easy_setopt(curl_handle, CURLOPT_HTTPHEADER, headers);
+
+	res = curl_easy_perform(curl_handle);
+	curl_easy_getinfo(curl_handle, CURLINFO_RESPONSE_CODE, &http_code);
+
+	if (headers)
+		curl_slist_free_all(headers);
+	free(response.memory);
+
+	if (res != CURLE_OK) {
+		pr_warn("Multipart abort failed: %s\n", curl_easy_strerror(res));
+		return -1;
+	}
+
+	pr_info("Multipart upload aborted: %s\n", object_key);
+	return 0;
+}
+
+/*
+ * =================================================================================
  * Fetch Range (existing)
  * =================================================================================
  */

--- a/criu/object-storage.c
+++ b/criu/object-storage.c
@@ -1692,6 +1692,91 @@ int object_storage_multipart_abort(const char *object_key, const char *upload_id
 
 /*
  * =================================================================================
+ * GET Object — fetch entire file (for metadata files with unknown size)
+ * =================================================================================
+ */
+
+int object_storage_get_object(const char *object_key, void **out_data, unsigned long *out_length)
+{
+	struct object_url_info url_info;
+	struct MemoryStruct chunk;
+	CURL *curl_handle;
+	CURLcode res;
+	long http_code = 0;
+	struct curl_slist *headers = NULL;
+
+	if (!object_key || !out_data || !out_length) {
+		pr_err("get_object: NULL parameter\n");
+		return -1;
+	}
+
+	*out_data = NULL;
+	*out_length = 0;
+
+	if (opts.express_one_zone) {
+		if (ensure_valid_session() != 0)
+			return -1;
+	}
+
+	if (_construct_object_url(object_key, &url_info) != 0)
+		return -1;
+
+	curl_handle = _get_curl_handle();
+	if (!curl_handle)
+		return -1;
+
+	chunk.memory = malloc(1);
+	chunk.size = 0;
+	chunk.capacity = 0;
+
+	curl_easy_setopt(curl_handle, CURLOPT_URL, url_info.url);
+	curl_easy_setopt(curl_handle, CURLOPT_HTTPGET, 1L);
+	curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, write_callback);
+	curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, &chunk);
+
+	/* SigV4: GET without Range header */
+	if (_build_auth_headers("GET", url_info.auth_host, url_info.canonical_uri,
+			       NULL, EMPTY_PAYLOAD_HASH, NULL, -1, &headers) != 0) {
+		free(chunk.memory);
+		return -1;
+	}
+	if (headers)
+		curl_easy_setopt(curl_handle, CURLOPT_HTTPHEADER, headers);
+
+	pr_debug("GET %s (full object)\n", url_info.url);
+
+	res = curl_easy_perform(curl_handle);
+	curl_easy_getinfo(curl_handle, CURLINFO_RESPONSE_CODE, &http_code);
+
+	if (headers)
+		curl_slist_free_all(headers);
+
+	if (res != CURLE_OK) {
+		pr_err("GET %s failed: %s\n", object_key, curl_easy_strerror(res));
+		free(chunk.memory);
+		return -1;
+	}
+
+	if (http_code == 404) {
+		pr_debug("GET %s: not found (HTTP 404)\n", object_key);
+		free(chunk.memory);
+		return -ENOENT;
+	}
+
+	if (http_code < 200 || http_code >= 300) {
+		pr_err("GET %s failed with HTTP %ld\n", object_key, http_code);
+		free(chunk.memory);
+		return -1;
+	}
+
+	pr_debug("GET %s: %lu bytes (HTTP %ld)\n", object_key, (unsigned long)chunk.size, http_code);
+	*out_data = chunk.memory;
+	*out_length = chunk.size;
+	return 0;
+}
+
+/*
+ * =================================================================================
  * Fetch Range (existing)
  * =================================================================================
  */

--- a/criu/object-storage.c
+++ b/criu/object-storage.c
@@ -1082,6 +1082,279 @@ void object_storage_cleanup(void)
 	pr_info("Object Storage client cleaned up (libcurl, PID: %d)\n", getpid());
 }
 
+/*
+ * =================================================================================
+ * URL Construction Helper
+ * =================================================================================
+ *
+ * Constructs S3 URL, auth host, and canonical URI from object key and options.
+ * Shared by fetch_range, put_object, and multipart operations.
+ */
+struct object_url_info {
+	char url[2048];
+	char auth_host[512];
+	char canonical_uri[2048];
+	char full_object_path[1024];
+};
+
+static int _construct_object_url(const char *object_key, struct object_url_info *info)
+{
+	char normalized_prefix[512];
+	const char *endpoint_url;
+	const char *hostname;
+
+	memset(info, 0, sizeof(*info));
+
+	/* Normalize the object prefix */
+	if (opts.object_storage_object_prefix) {
+		const char *original_prefix = opts.object_storage_object_prefix;
+		size_t prefix_len = strlen(original_prefix);
+		if (prefix_len == 1 && original_prefix[0] == '/') {
+			normalized_prefix[0] = '\0';
+		} else if (prefix_len > 0) {
+			const char *start = original_prefix;
+			size_t copy_len = prefix_len;
+			if (original_prefix[0] == '/') {
+				start++;
+				copy_len--;
+			}
+			snprintf(normalized_prefix, sizeof(normalized_prefix), "%.*s", (int)copy_len, start);
+			if (copy_len > 0 && normalized_prefix[copy_len - 1] != '/') {
+				size_t current_len = strlen(normalized_prefix);
+				if (current_len < sizeof(normalized_prefix) - 1) {
+					normalized_prefix[current_len] = '/';
+					normalized_prefix[current_len + 1] = '\0';
+				}
+			}
+		} else {
+			normalized_prefix[0] = '\0';
+		}
+	} else {
+		normalized_prefix[0] = '\0';
+	}
+
+	/* Handle endpoint URL and extract hostname */
+	endpoint_url = opts.object_storage_endpoint_url;
+	hostname = _strip_scheme(endpoint_url);
+
+	/* Build full object path */
+	if (normalized_prefix[0] != '\0' && strncmp(object_key, normalized_prefix, strlen(normalized_prefix)) == 0) {
+		snprintf(info->full_object_path, sizeof(info->full_object_path), "%s", object_key);
+	} else {
+		snprintf(info->full_object_path, sizeof(info->full_object_path), "%s%s", normalized_prefix, object_key);
+	}
+
+	/* Construct URL */
+	if (opts.express_one_zone) {
+		snprintf(info->url, sizeof(info->url), "https://%s.%s/%s",
+			 opts.object_storage_bucket, opts.object_storage_endpoint_url, info->full_object_path);
+	} else if (opts.object_storage_bucket && opts.object_storage_bucket[0] != '\0') {
+		if (opts.object_storage_path_style) {
+			if (hostname != endpoint_url) {
+				snprintf(info->url, sizeof(info->url), "%.*s%s/%s/%s",
+					 (int)(hostname - endpoint_url), endpoint_url,
+					 hostname, opts.object_storage_bucket, info->full_object_path);
+			} else {
+				snprintf(info->url, sizeof(info->url), "https://%s/%s/%s",
+					 hostname, opts.object_storage_bucket, info->full_object_path);
+			}
+		} else {
+			if (hostname != endpoint_url) {
+				snprintf(info->url, sizeof(info->url), "%.*s%s.%s/%s",
+					 (int)(hostname - endpoint_url), endpoint_url,
+					 opts.object_storage_bucket, hostname, info->full_object_path);
+			} else {
+				snprintf(info->url, sizeof(info->url), "https://%s.%s/%s",
+					 opts.object_storage_bucket, hostname, info->full_object_path);
+			}
+		}
+	} else {
+		if (hostname != endpoint_url) {
+			snprintf(info->url, sizeof(info->url), "%s/%s", endpoint_url, info->full_object_path);
+		} else {
+			snprintf(info->url, sizeof(info->url), "https://%s/%s", hostname, info->full_object_path);
+		}
+	}
+
+	/* Construct auth host */
+	if (opts.express_one_zone) {
+		snprintf(info->auth_host, sizeof(info->auth_host), "%s.%s",
+			 opts.object_storage_bucket, opts.object_storage_endpoint_url);
+	} else if (opts.object_storage_path_style ||
+		   !opts.object_storage_bucket || !opts.object_storage_bucket[0]) {
+		snprintf(info->auth_host, sizeof(info->auth_host), "%s", hostname);
+	} else {
+		snprintf(info->auth_host, sizeof(info->auth_host), "%s.%s",
+			 opts.object_storage_bucket, hostname);
+	}
+	/* Strip trailing slash from auth_host */
+	{
+		size_t hlen = strlen(info->auth_host);
+		if (hlen > 0 && info->auth_host[hlen - 1] == '/')
+			info->auth_host[hlen - 1] = '\0';
+	}
+
+	/* Construct canonical URI */
+	if (!opts.express_one_zone && opts.object_storage_path_style &&
+	    opts.object_storage_bucket && opts.object_storage_bucket[0]) {
+		snprintf(info->canonical_uri, sizeof(info->canonical_uri), "/%s/%s",
+			 opts.object_storage_bucket, info->full_object_path);
+	} else {
+		snprintf(info->canonical_uri, sizeof(info->canonical_uri), "/%s", info->full_object_path);
+	}
+
+	return 0;
+}
+
+/*
+ * Get curl handle appropriate for current thread context.
+ * Returns NULL on failure.
+ */
+static CURL *_get_curl_handle(void)
+{
+	CURL *handle;
+
+	if (!is_main_thread()) {
+		handle = get_thread_curl_handle();
+		if (!handle)
+			pr_err("Failed to get thread-local curl handle\n");
+		return handle;
+	}
+
+	handle = get_curl_handle_for_current_process();
+	if (!handle) {
+		pr_warn("Failed to get process curl handle, using one-time handle\n");
+		handle = curl_easy_init();
+		if (handle)
+			set_fixed_curl_options(handle);
+		return handle;
+	}
+
+	curl_easy_reset(handle);
+	set_fixed_curl_options(handle);
+	return handle;
+}
+
+/*
+ * =================================================================================
+ * PUT Object — Simple upload for small files (metadata, pagemap, etc.)
+ * =================================================================================
+ */
+
+/* Read callback for curl PUT upload */
+struct UploadContext {
+	const char *data;
+	unsigned long size;
+	unsigned long offset;
+};
+
+static size_t _upload_read_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
+{
+	struct UploadContext *ctx = (struct UploadContext *)userdata;
+	size_t remaining = ctx->size - ctx->offset;
+	size_t to_copy = size * nmemb;
+	if (to_copy > remaining)
+		to_copy = remaining;
+	memcpy(ptr, ctx->data + ctx->offset, to_copy);
+	ctx->offset += to_copy;
+	return to_copy;
+}
+
+int object_storage_put_object(const char *object_key, const void *data, unsigned long length)
+{
+	struct object_url_info url_info;
+	struct UploadContext upload_ctx;
+	struct MemoryStruct response;
+	CURL *curl_handle;
+	CURLcode res;
+	long http_code = 0;
+	struct curl_slist *headers = NULL;
+	char content_sha256[65];
+
+	if (!object_key || !data) {
+		pr_err("put_object: NULL object_key or data\n");
+		return -1;
+	}
+
+	/* Ensure valid session for Express One Zone */
+	if (opts.express_one_zone) {
+		if (ensure_valid_session() != 0)
+			return -1;
+	}
+
+	/* Construct URL */
+	if (_construct_object_url(object_key, &url_info) != 0)
+		return -1;
+
+	/* Compute SHA256 of the body */
+	_sha256_hex((const char *)data, length, content_sha256);
+
+	/* Get curl handle */
+	curl_handle = _get_curl_handle();
+	if (!curl_handle)
+		return -1;
+
+	/* Setup upload context */
+	upload_ctx.data = (const char *)data;
+	upload_ctx.size = length;
+	upload_ctx.offset = 0;
+
+	/* Setup response buffer */
+	response.memory = malloc(1);
+	response.size = 0;
+	response.capacity = 0;
+
+	/* Configure curl for PUT */
+	curl_easy_setopt(curl_handle, CURLOPT_URL, url_info.url);
+	curl_easy_setopt(curl_handle, CURLOPT_UPLOAD, 1L);
+	curl_easy_setopt(curl_handle, CURLOPT_READFUNCTION, _upload_read_callback);
+	curl_easy_setopt(curl_handle, CURLOPT_READDATA, &upload_ctx);
+	curl_easy_setopt(curl_handle, CURLOPT_INFILESIZE_LARGE, (curl_off_t)length);
+	curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, write_callback);
+	curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, &response);
+
+	/* Build auth headers */
+	if (_build_auth_headers("PUT", url_info.auth_host, url_info.canonical_uri, NULL,
+			       content_sha256, NULL, (long)length, &headers) != 0) {
+		free(response.memory);
+		return -1;
+	}
+	if (headers)
+		curl_easy_setopt(curl_handle, CURLOPT_HTTPHEADER, headers);
+
+	pr_info("PUT %s (%lu bytes)\n", url_info.url, length);
+
+	/* Execute */
+	res = curl_easy_perform(curl_handle);
+	curl_easy_getinfo(curl_handle, CURLINFO_RESPONSE_CODE, &http_code);
+
+	if (headers)
+		curl_slist_free_all(headers);
+
+	if (res != CURLE_OK) {
+		pr_err("PUT failed: %s\n", curl_easy_strerror(res));
+		free(response.memory);
+		return -1;
+	}
+
+	if (http_code < 200 || http_code >= 300) {
+		pr_err("PUT failed with HTTP %ld: %.*s\n", http_code,
+		       (int)response.size, response.memory);
+		free(response.memory);
+		return -1;
+	}
+
+	pr_info("PUT %s succeeded (HTTP %ld)\n", object_key, http_code);
+	free(response.memory);
+	return 0;
+}
+
+/*
+ * =================================================================================
+ * Fetch Range (existing)
+ * =================================================================================
+ */
+
 int object_storage_fetch_range(const char *object_key, unsigned long offset, unsigned long length, void *buffer)
 {
 	CURL *curl_handle;

--- a/criu/object-storage.c
+++ b/criu/object-storage.c
@@ -241,12 +241,12 @@ static int _build_sigv4_headers(const char *access_key, const char *secret_key,
 	signed_headers[0] = '\0';
 	canonical_headers[0] = '\0';
 
-	/* content-length (only for PUT/POST with body) */
-	if (content_length >= 0) {
-		pos += snprintf(canonical_headers + pos, sizeof(canonical_headers) - pos,
-				"content-length:%ld\n", content_length);
-		strncat(signed_headers, "content-length;", sizeof(signed_headers) - strlen(signed_headers) - 1);
-	}
+	/*
+	 * Note: content-length is NOT included in signed headers.
+	 * curl sets Content-Length automatically. Including it in the
+	 * signature causes SignatureDoesNotMatch on AWS S3 because
+	 * curl may format the value differently than our signed version.
+	 */
 
 	/* host (always) */
 	pos += snprintf(canonical_headers + pos, sizeof(canonical_headers) - pos,
@@ -292,6 +292,9 @@ static int _build_sigv4_headers(const char *access_key, const char *secret_key,
 	/* Hash canonical request */
 	_sha256_hex(canonical_request, strlen(canonical_request), canonical_request_hash);
 
+	pr_debug("SigV4 canonical_request:\n---\n%s\n---\nhash: %s\n",
+		 canonical_request, canonical_request_hash);
+
 	/* Build credential scope and string to sign */
 	snprintf(credential_scope, sizeof(credential_scope), "%s/%s/%s/aws4_request",
 		 date_stamp, region, service);
@@ -329,11 +332,7 @@ static int _build_sigv4_headers(const char *access_key, const char *secret_key,
 		 "X-Amz-Content-Sha256: %s", content_sha256);
 	*headers = curl_slist_append(*headers, x_amz_content_sha256_header);
 
-	if (content_length >= 0) {
-		char cl_header[64];
-		snprintf(cl_header, sizeof(cl_header), "Content-Length: %ld", content_length);
-		*headers = curl_slist_append(*headers, cl_header);
-	}
+	/* Content-Length is set by curl automatically via CURLOPT_INFILESIZE_LARGE */
 
 	if (session_token) {
 		char token_header[2100];

--- a/criu/object-storage.c
+++ b/criu/object-storage.c
@@ -177,30 +177,37 @@ static const char *_strip_scheme(const char *url)
 }
 
 /*
- * Build SigV4 authentication headers for a GET request with Range header.
+ * Build SigV4 authentication headers for an S3 request.
  *
  * Parameters:
  *   access_key    - AWS access key ID (or session access key for Express)
  *   secret_key    - AWS secret access key (or session secret key for Express)
  *   session_token - Session token (NULL for standard S3/MinIO)
  *   region        - AWS region (e.g., "us-east-1")
- *   host          - Host header value, scheme-free (e.g., "bucket.s3.amazonaws.com" or "minio:9000")
- *   canonical_uri - URI path (e.g., "/object/key" or "/bucket/object/key")
- *   range_value   - Range header value (e.g., "bytes=0-4095")
+ *   method        - HTTP method ("GET", "PUT", "POST", "DELETE")
+ *   host          - Host header value, scheme-free (e.g., "bucket.s3.amazonaws.com")
+ *   canonical_uri - URI path (e.g., "/object/key")
+ *   query_string  - Canonical query string (NULL or "" for none)
+ *   content_sha256 - SHA256 hex of request body (use EMPTY_PAYLOAD_HASH for no body)
+ *   range_value   - Range header value (NULL if not applicable)
+ *   content_length - Content-Length value (-1 if not applicable)
  *   headers       - Output: curl_slist with Authorization, X-Amz-Date, etc.
  *
  * Returns 0 on success, -1 on failure.
  */
+#define EMPTY_PAYLOAD_HASH "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
 static int _build_sigv4_headers(const char *access_key, const char *secret_key,
 				const char *session_token, const char *region,
-				const char *host, const char *canonical_uri,
-				const char *range_value, struct curl_slist **headers)
+				const char *method, const char *host,
+				const char *canonical_uri, const char *query_string,
+				const char *content_sha256, const char *range_value,
+				long content_length, struct curl_slist **headers)
 {
 	char amz_date[17];
 	char date_stamp[9];
-	char payload_hash[65];
 	char canonical_headers[4096];
-	char signed_headers[128];
+	char signed_headers[256];
 	char canonical_request[8192];
 	char canonical_request_hash[65];
 	char string_to_sign[512];
@@ -211,49 +218,76 @@ static int _build_sigv4_headers(const char *access_key, const char *secret_key,
 	char x_amz_content_sha256_header[100];
 	time_t now;
 	struct tm *tm_gmt;
-	const char *method = "GET";
 	const char *service = "s3";
-	const char *canonical_querystring = "";
+	const char *qs = (query_string && query_string[0]) ? query_string : "";
 	unsigned char *signing_key;
 	unsigned int signing_key_len;
 	unsigned char *signature_raw;
 	unsigned int signature_raw_len;
 	int i;
+	int pos;
 
 	now = time(NULL);
 	tm_gmt = gmtime(&now);
 	strftime(amz_date, sizeof(amz_date), "%Y%m%dT%H%M%SZ", tm_gmt);
 	strftime(date_stamp, sizeof(date_stamp), "%Y%m%d", tm_gmt);
 
-	/* Payload hash (empty for GET) */
-	_sha256_hex("", 0, payload_hash);
+	/*
+	 * Build signed headers and canonical headers.
+	 * Headers MUST be sorted alphabetically by name.
+	 * Conditionally include: content-length, range, x-amz-s3session-token.
+	 */
+	pos = 0;
+	signed_headers[0] = '\0';
+	canonical_headers[0] = '\0';
 
-	/* Build signed headers string and canonical headers */
+	/* content-length (only for PUT/POST with body) */
+	if (content_length >= 0) {
+		pos += snprintf(canonical_headers + pos, sizeof(canonical_headers) - pos,
+				"content-length:%ld\n", content_length);
+		strncat(signed_headers, "content-length;", sizeof(signed_headers) - strlen(signed_headers) - 1);
+	}
+
+	/* host (always) */
+	pos += snprintf(canonical_headers + pos, sizeof(canonical_headers) - pos,
+			"host:%s\n", host);
+	strncat(signed_headers, "host;", sizeof(signed_headers) - strlen(signed_headers) - 1);
+
+	/* range (only for GET with range) */
+	if (range_value) {
+		pos += snprintf(canonical_headers + pos, sizeof(canonical_headers) - pos,
+				"range:%s\n", range_value);
+		strncat(signed_headers, "range;", sizeof(signed_headers) - strlen(signed_headers) - 1);
+	}
+
+	/* x-amz-content-sha256 (always) */
+	pos += snprintf(canonical_headers + pos, sizeof(canonical_headers) - pos,
+			"x-amz-content-sha256:%s\n", content_sha256);
+	strncat(signed_headers, "x-amz-content-sha256;", sizeof(signed_headers) - strlen(signed_headers) - 1);
+
+	/* x-amz-date (always) */
+	pos += snprintf(canonical_headers + pos, sizeof(canonical_headers) - pos,
+			"x-amz-date:%s\n", amz_date);
+	strncat(signed_headers, "x-amz-date;", sizeof(signed_headers) - strlen(signed_headers) - 1);
+
+	/* x-amz-s3session-token (Express One Zone only) */
 	if (session_token) {
-		snprintf(signed_headers, sizeof(signed_headers),
-			 "host;range;x-amz-content-sha256;x-amz-date;x-amz-s3session-token");
-		snprintf(canonical_headers, sizeof(canonical_headers),
-			 "host:%s\n"
-			 "range:%s\n"
-			 "x-amz-content-sha256:%s\n"
-			 "x-amz-date:%s\n"
-			 "x-amz-s3session-token:%s\n",
-			 host, range_value, payload_hash, amz_date, session_token);
-	} else {
-		snprintf(signed_headers, sizeof(signed_headers),
-			 "host;range;x-amz-content-sha256;x-amz-date");
-		snprintf(canonical_headers, sizeof(canonical_headers),
-			 "host:%s\n"
-			 "range:%s\n"
-			 "x-amz-content-sha256:%s\n"
-			 "x-amz-date:%s\n",
-			 host, range_value, payload_hash, amz_date);
+		pos += snprintf(canonical_headers + pos, sizeof(canonical_headers) - pos,
+				"x-amz-s3session-token:%s\n", session_token);
+		strncat(signed_headers, "x-amz-s3session-token;", sizeof(signed_headers) - strlen(signed_headers) - 1);
+	}
+
+	/* Remove trailing semicolon from signed_headers */
+	{
+		size_t sh_len = strlen(signed_headers);
+		if (sh_len > 0 && signed_headers[sh_len - 1] == ';')
+			signed_headers[sh_len - 1] = '\0';
 	}
 
 	/* Build canonical request */
 	snprintf(canonical_request, sizeof(canonical_request), "%s\n%s\n%s\n%s\n%s\n%s",
-		 method, canonical_uri, canonical_querystring,
-		 canonical_headers, signed_headers, payload_hash);
+		 method, canonical_uri, qs,
+		 canonical_headers, signed_headers, content_sha256);
 
 	/* Hash canonical request */
 	_sha256_hex(canonical_request, strlen(canonical_request), canonical_request_hash);
@@ -287,13 +321,19 @@ static int _build_sigv4_headers(const char *access_key, const char *secret_key,
 		 "Authorization: AWS4-HMAC-SHA256 Credential=%s/%s, SignedHeaders=%s, Signature=%s",
 		 access_key, credential_scope, signed_headers, signature_hex);
 
-	/* Append headers */
+	/* Append headers to curl_slist */
 	snprintf(x_amz_date_header, sizeof(x_amz_date_header), "X-Amz-Date: %s", amz_date);
 	*headers = curl_slist_append(*headers, x_amz_date_header);
 
 	snprintf(x_amz_content_sha256_header, sizeof(x_amz_content_sha256_header),
-		 "X-Amz-Content-Sha256: %s", payload_hash);
+		 "X-Amz-Content-Sha256: %s", content_sha256);
 	*headers = curl_slist_append(*headers, x_amz_content_sha256_header);
+
+	if (content_length >= 0) {
+		char cl_header[64];
+		snprintf(cl_header, sizeof(cl_header), "Content-Length: %ld", content_length);
+		*headers = curl_slist_append(*headers, cl_header);
+	}
 
 	if (session_token) {
 		char token_header[2100];
@@ -311,34 +351,40 @@ static int _build_sigv4_headers(const char *access_key, const char *secret_key,
  * Build authentication headers for object storage requests.
  * Single entry point for all auth methods — dispatches to provider-specific implementations.
  *
- * Currently supports:
- *   - AWS SigV4 (S3, S3 Express One Zone, MinIO, S3-compatible)
- *
- * Future extension points (add branches here):
- *   - Azure Blob Storage: SharedKey / SAS token
- *   - GCP Cloud Storage: OAuth2 Bearer token
- *   - S3-compatible with HMAC: reuses _build_sigv4_headers()
+ * Parameters:
+ *   method        - HTTP method ("GET", "PUT", "POST", "DELETE")
+ *   host          - Host header value, scheme-free
+ *   canonical_uri - URI path
+ *   query_string  - Canonical query string (NULL or "" for none)
+ *   content_sha256 - SHA256 hex of body (EMPTY_PAYLOAD_HASH for no body)
+ *   range_value   - Range header value (NULL if not applicable)
+ *   content_length - Content-Length (-1 if not applicable)
+ *   headers       - Output: curl_slist
  */
-static int _build_auth_headers(const char *host, const char *canonical_uri,
-			       const char *range_value, struct curl_slist **headers)
+static int _build_auth_headers(const char *method, const char *host,
+			       const char *canonical_uri, const char *query_string,
+			       const char *content_sha256, const char *range_value,
+			       long content_length, struct curl_slist **headers)
 {
 	if (opts.express_one_zone && opts.aws_access_key && opts.aws_secret_key) {
-		/* AWS S3 Express One Zone: SigV4 with temporary session credentials */
 		pr_debug("Auth: SigV4 with Express One Zone session credentials\n");
 		return _build_sigv4_headers(g_session_access_key, g_session_secret_key,
 					    g_session_token, opts.aws_region,
-					    host, canonical_uri, range_value, headers);
+					    method, host, canonical_uri, query_string,
+					    content_sha256, range_value,
+					    content_length, headers);
 	}
 
 	if (opts.aws_access_key && opts.aws_secret_key) {
-		/* AWS S3 / MinIO / S3-compatible: SigV4 with IAM credentials */
 		pr_debug("Auth: SigV4 with standard credentials\n");
 		return _build_sigv4_headers(opts.aws_access_key, opts.aws_secret_key,
 					    NULL, opts.aws_region,
-					    host, canonical_uri, range_value, headers);
+					    method, host, canonical_uri, query_string,
+					    content_sha256, range_value,
+					    content_length, headers);
 	}
 
-	/* No credentials — anonymous access (e.g., public bucket) */
+	/* No credentials — anonymous access */
 	return 0;
 }
 
@@ -1257,7 +1303,8 @@ int object_storage_fetch_range(const char *object_key, unsigned long offset, uns
 		snprintf(range_header_value, sizeof(range_header_value), "bytes=%lu-%lu",
 			 offset, offset + length - 1);
 
-		if (_build_auth_headers(auth_host, auth_canonical_uri, range_header_value, &headers) != 0) {
+		if (_build_auth_headers("GET", auth_host, auth_canonical_uri, NULL,
+				       EMPTY_PAYLOAD_HASH, range_header_value, -1, &headers) != 0) {
 			free(error_response.memory);
 			return -1;
 		}

--- a/criu/page-xfer.c
+++ b/criu/page-xfer.c
@@ -433,9 +433,9 @@ err_pmi:
  * S3 functions upload pages data via multipart and pagemap via put_object.
  */
 
-#define S3_PART_SIZE (8 * 1024 * 1024) /* 8MB per multipart part */
+#define OBJECT_STORAGE_PART_SIZE (8 * 1024 * 1024) /* 8MB per multipart part */
 
-static int write_pages_s3(struct page_xfer *xfer, int p, unsigned long len)
+static int write_pages_object_storage(struct page_xfer *xfer, int p, unsigned long len)
 {
 	unsigned long remaining;
 	ssize_t nread;
@@ -446,7 +446,7 @@ static int write_pages_s3(struct page_xfer *xfer, int p, unsigned long len)
 	if (ret < 0)
 		return ret;
 
-	if (!xfer->s3.active)
+	if (!xfer->object_storage.active)
 		return 0;
 
 	/*
@@ -460,7 +460,7 @@ static int write_pages_s3(struct page_xfer *xfer, int p, unsigned long len)
 
 		cur_pos = lseek(img_raw_fd(xfer->pi), 0, SEEK_CUR);
 		if (cur_pos < 0 || (unsigned long)cur_pos < len) {
-			pr_err("S3: failed to seek back in pages image\n");
+			pr_err("object_storage: failed to seek back in pages image\n");
 			return -1;
 		}
 		lseek(img_raw_fd(xfer->pi), cur_pos - len, SEEK_SET);
@@ -473,7 +473,7 @@ static int write_pages_s3(struct page_xfer *xfer, int p, unsigned long len)
 		while (remaining > 0) {
 			nread = read(img_raw_fd(xfer->pi), read_buf + (len - remaining), remaining);
 			if (nread <= 0) {
-				pr_err("S3: failed to read back pages data\n");
+				pr_err("object_storage: failed to read back pages data\n");
 				xfree(read_buf);
 				return -1;
 			}
@@ -483,50 +483,50 @@ static int write_pages_s3(struct page_xfer *xfer, int p, unsigned long len)
 		/* Seek back to end */
 		lseek(img_raw_fd(xfer->pi), cur_pos, SEEK_SET);
 
-		/* Accumulate in part buffer, flush when >= S3_PART_SIZE */
+		/* Accumulate in part buffer, flush when >= OBJECT_STORAGE_PART_SIZE */
 		{
 			unsigned long src_off = 0;
 			while (src_off < len) {
-				unsigned long space = xfer->s3.part_buf_cap - xfer->s3.part_buf_used;
+				unsigned long space = xfer->object_storage.part_buf_cap - xfer->object_storage.part_buf_used;
 				unsigned long to_copy = len - src_off;
 
 				if (to_copy > space)
 					to_copy = space;
-				memcpy((char *)xfer->s3.part_buf + xfer->s3.part_buf_used,
+				memcpy((char *)xfer->object_storage.part_buf + xfer->object_storage.part_buf_used,
 				       (char *)read_buf + src_off, to_copy);
-				xfer->s3.part_buf_used += to_copy;
+				xfer->object_storage.part_buf_used += to_copy;
 				src_off += to_copy;
 
-				if (xfer->s3.part_buf_used >= S3_PART_SIZE) {
+				if (xfer->object_storage.part_buf_used >= OBJECT_STORAGE_PART_SIZE) {
 					char etag[256];
 
 					/* Grow etags array if needed */
-					if (xfer->s3.etags_count >= xfer->s3.etags_cap) {
-						int new_cap = xfer->s3.etags_cap * 2;
-						char **new_etags = xrealloc(xfer->s3.etags, new_cap * sizeof(char *));
+					if (xfer->object_storage.etags_count >= xfer->object_storage.etags_cap) {
+						int new_cap = xfer->object_storage.etags_cap * 2;
+						char **new_etags = xrealloc(xfer->object_storage.etags, new_cap * sizeof(char *));
 						if (!new_etags) {
 							xfree(read_buf);
 							return -1;
 						}
-						xfer->s3.etags = new_etags;
-						xfer->s3.etags_cap = new_cap;
+						xfer->object_storage.etags = new_etags;
+						xfer->object_storage.etags_cap = new_cap;
 					}
 
-					xfer->s3.part_number++;
+					xfer->object_storage.part_number++;
 					ret = object_storage_multipart_upload_part(
-						xfer->s3.pages_key, xfer->s3.upload_id,
-						xfer->s3.part_number,
-						xfer->s3.part_buf, xfer->s3.part_buf_used,
+						xfer->object_storage.pages_key, xfer->object_storage.upload_id,
+						xfer->object_storage.part_number,
+						xfer->object_storage.part_buf, xfer->object_storage.part_buf_used,
 						etag, sizeof(etag));
 					if (ret < 0) {
-						pr_err("S3: multipart upload part %d failed\n",
-						       xfer->s3.part_number);
+						pr_err("object_storage: multipart upload part %d failed\n",
+						       xfer->object_storage.part_number);
 						xfree(read_buf);
 						return -1;
 					}
-					xfer->s3.etags[xfer->s3.etags_count] = xstrdup(etag);
-					xfer->s3.etags_count++;
-					xfer->s3.part_buf_used = 0;
+					xfer->object_storage.etags[xfer->object_storage.etags_count] = xstrdup(etag);
+					xfer->object_storage.etags_count++;
+					xfer->object_storage.part_buf_used = 0;
 				}
 			}
 		}
@@ -536,59 +536,59 @@ static int write_pages_s3(struct page_xfer *xfer, int p, unsigned long len)
 	return 0;
 }
 
-static int write_pagemap_s3(struct page_xfer *xfer, struct iovec *iov, u32 flags)
+static int write_pagemap_object_storage(struct page_xfer *xfer, struct iovec *iov, u32 flags)
 {
 	/* Write to local file first */
 	return write_pagemap_loc(xfer, iov, flags);
 	/* Pagemap is uploaded on close via put_object from the local file */
 }
 
-static void close_page_xfer_s3(struct page_xfer *xfer)
+static void close_page_xfer_object_storage(struct page_xfer *xfer)
 {
 	int i;
 
-	if (xfer->s3.active) {
+	if (xfer->object_storage.active) {
 		/* Flush remaining part buffer */
-		if (xfer->s3.part_buf_used > 0 || xfer->s3.part_number == 0) {
+		if (xfer->object_storage.part_buf_used > 0 || xfer->object_storage.part_number == 0) {
 			char etag[256];
 			int ret;
 
-			if (xfer->s3.etags_count >= xfer->s3.etags_cap) {
-				int new_cap = xfer->s3.etags_cap + 1;
-				char **new_etags = xrealloc(xfer->s3.etags, new_cap * sizeof(char *));
+			if (xfer->object_storage.etags_count >= xfer->object_storage.etags_cap) {
+				int new_cap = xfer->object_storage.etags_cap + 1;
+				char **new_etags = xrealloc(xfer->object_storage.etags, new_cap * sizeof(char *));
 				if (new_etags) {
-					xfer->s3.etags = new_etags;
-					xfer->s3.etags_cap = new_cap;
+					xfer->object_storage.etags = new_etags;
+					xfer->object_storage.etags_cap = new_cap;
 				}
 			}
 
-			if (xfer->s3.part_buf_used > 0 || xfer->s3.part_number == 0) {
-				xfer->s3.part_number++;
+			if (xfer->object_storage.part_buf_used > 0 || xfer->object_storage.part_number == 0) {
+				xfer->object_storage.part_number++;
 				ret = object_storage_multipart_upload_part(
-					xfer->s3.pages_key, xfer->s3.upload_id,
-					xfer->s3.part_number,
-					xfer->s3.part_buf,
-					xfer->s3.part_buf_used > 0 ? xfer->s3.part_buf_used : 0,
+					xfer->object_storage.pages_key, xfer->object_storage.upload_id,
+					xfer->object_storage.part_number,
+					xfer->object_storage.part_buf,
+					xfer->object_storage.part_buf_used > 0 ? xfer->object_storage.part_buf_used : 0,
 					etag, sizeof(etag));
 				if (ret < 0) {
-					pr_err("S3: final part upload failed, aborting\n");
-					object_storage_multipart_abort(xfer->s3.pages_key,
-								       xfer->s3.upload_id);
+					pr_err("object_storage: final part upload failed, aborting\n");
+					object_storage_multipart_abort(xfer->object_storage.pages_key,
+								       xfer->object_storage.upload_id);
 					goto cleanup;
 				}
-				xfer->s3.etags[xfer->s3.etags_count] = xstrdup(etag);
-				xfer->s3.etags_count++;
+				xfer->object_storage.etags[xfer->object_storage.etags_count] = xstrdup(etag);
+				xfer->object_storage.etags_count++;
 			}
 		}
 
 		/* Complete multipart upload */
-		if (xfer->s3.etags_count > 0) {
+		if (xfer->object_storage.etags_count > 0) {
 			int ret;
 			ret = object_storage_multipart_complete(
-				xfer->s3.pages_key, xfer->s3.upload_id,
-				xfer->s3.etags_count, (const char **)xfer->s3.etags);
+				xfer->object_storage.pages_key, xfer->object_storage.upload_id,
+				xfer->object_storage.etags_count, (const char **)xfer->object_storage.etags);
 			if (ret < 0)
-				pr_err("S3: multipart complete failed for %s\n", xfer->s3.pages_key);
+				pr_err("object_storage: multipart complete failed for %s\n", xfer->object_storage.pages_key);
 		}
 
 		/* Upload pagemap from local file via put_object */
@@ -614,7 +614,7 @@ static void close_page_xfer_s3(struct page_xfer *xfer)
 						rd += nr;
 					}
 					if (rd == (unsigned long)pmi_size) {
-						object_storage_put_object(xfer->s3.pagemap_key,
+						object_storage_put_object(xfer->object_storage.pagemap_key,
 									  pmi_data, pmi_size);
 					}
 					xfree(pmi_data);
@@ -624,18 +624,18 @@ static void close_page_xfer_s3(struct page_xfer *xfer)
 
 cleanup:
 		/* Free etags */
-		for (i = 0; i < xfer->s3.etags_count; i++)
-			xfree(xfer->s3.etags[i]);
-		xfree(xfer->s3.etags);
-		xfree(xfer->s3.part_buf);
-		xfer->s3.active = 0;
+		for (i = 0; i < xfer->object_storage.etags_count; i++)
+			xfree(xfer->object_storage.etags[i]);
+		xfree(xfer->object_storage.etags);
+		xfree(xfer->object_storage.part_buf);
+		xfer->object_storage.active = 0;
 	}
 
 	/* Close local files */
 	close_page_xfer(xfer);
 }
 
-static int open_page_s3_xfer(struct page_xfer *xfer, int fd_type, unsigned long img_id)
+static int open_page_object_storage_xfer(struct page_xfer *xfer, int fd_type, unsigned long img_id)
 {
 	int ret;
 
@@ -644,50 +644,50 @@ static int open_page_s3_xfer(struct page_xfer *xfer, int fd_type, unsigned long 
 	if (ret < 0)
 		return ret;
 
-	/* Initialize S3 upload state */
-	memset(&xfer->s3, 0, sizeof(xfer->s3));
+	/* Initialize object storage upload state */
+	memset(&xfer->object_storage, 0, sizeof(xfer->object_storage));
 
 	/* Construct S3 keys using the image filenames */
-	snprintf(xfer->s3.pages_key, sizeof(xfer->s3.pages_key),
+	snprintf(xfer->object_storage.pages_key, sizeof(xfer->object_storage.pages_key),
 		 "pages-%lu.img", img_id);
-	snprintf(xfer->s3.pagemap_key, sizeof(xfer->s3.pagemap_key),
+	snprintf(xfer->object_storage.pagemap_key, sizeof(xfer->object_storage.pagemap_key),
 		 "pagemap-%lu.img", img_id);
 
 	/* Allocate part buffer */
-	xfer->s3.part_buf_cap = S3_PART_SIZE;
-	xfer->s3.part_buf = xmalloc(S3_PART_SIZE);
-	if (!xfer->s3.part_buf)
+	xfer->object_storage.part_buf_cap = OBJECT_STORAGE_PART_SIZE;
+	xfer->object_storage.part_buf = xmalloc(OBJECT_STORAGE_PART_SIZE);
+	if (!xfer->object_storage.part_buf)
 		return -1;
-	xfer->s3.part_buf_used = 0;
-	xfer->s3.part_number = 0;
+	xfer->object_storage.part_buf_used = 0;
+	xfer->object_storage.part_number = 0;
 
 	/* Allocate etags array */
-	xfer->s3.etags_cap = 64;
-	xfer->s3.etags = xmalloc(xfer->s3.etags_cap * sizeof(char *));
-	if (!xfer->s3.etags) {
-		xfree(xfer->s3.part_buf);
+	xfer->object_storage.etags_cap = 64;
+	xfer->object_storage.etags = xmalloc(xfer->object_storage.etags_cap * sizeof(char *));
+	if (!xfer->object_storage.etags) {
+		xfree(xfer->object_storage.part_buf);
 		return -1;
 	}
-	xfer->s3.etags_count = 0;
+	xfer->object_storage.etags_count = 0;
 
 	/* Initiate multipart upload for pages */
-	ret = object_storage_multipart_init(xfer->s3.pages_key,
-					    xfer->s3.upload_id,
-					    sizeof(xfer->s3.upload_id));
+	ret = object_storage_multipart_init(xfer->object_storage.pages_key,
+					    xfer->object_storage.upload_id,
+					    sizeof(xfer->object_storage.upload_id));
 	if (ret < 0) {
-		pr_err("S3: failed to initiate multipart upload for %s\n",
-		       xfer->s3.pages_key);
-		xfree(xfer->s3.part_buf);
-		xfree(xfer->s3.etags);
+		pr_err("object_storage: failed to initiate multipart upload for %s\n",
+		       xfer->object_storage.pages_key);
+		xfree(xfer->object_storage.part_buf);
+		xfree(xfer->object_storage.etags);
 		return -1;
 	}
 
-	xfer->s3.active = 1;
+	xfer->object_storage.active = 1;
 
 	/* Override write/close functions with S3 wrappers */
-	xfer->write_pagemap = write_pagemap_s3;
-	xfer->write_pages = write_pages_s3;
-	xfer->close = close_page_xfer_s3;
+	xfer->write_pagemap = write_pagemap_object_storage;
+	xfer->write_pages = write_pages_object_storage;
+	xfer->close = close_page_xfer_object_storage;
 
 	return 0;
 }
@@ -700,7 +700,7 @@ int open_page_xfer(struct page_xfer *xfer, int fd_type, unsigned long img_id)
 	if (opts.use_page_server)
 		return open_page_server_xfer(xfer, fd_type, img_id);
 	else if (opts.object_storage_upload)
-		return open_page_s3_xfer(xfer, fd_type, img_id);
+		return open_page_object_storage_xfer(xfer, fd_type, img_id);
 	else
 		return open_page_local_xfer(xfer, fd_type, img_id);
 }

--- a/criu/page-xfer.c
+++ b/criu/page-xfer.c
@@ -405,7 +405,44 @@ static int open_page_local_xfer(struct page_xfer *xfer, int fd_type, unsigned lo
 			goto err_pi;
 		}
 
-		ret = open_page_read_at(pfd, img_id, xfer->parent, pr_flags);
+		/*
+		 * When object-storage-upload is enabled, parent dir may be
+		 * empty (S3-only mode). Swap prefix to parent's so that
+		 * do_open_image() S3 fallback fetches from the right prefix.
+		 */
+		if (opts.object_storage_upload) {
+			void *prefix_data = NULL;
+			unsigned long prefix_len = 0;
+			char *parent_prefix = NULL;
+			char *saved_prefix;
+			int s3_ret;
+
+			s3_ret = object_storage_get_object("parent-prefix",
+							   &prefix_data, &prefix_len);
+			if (s3_ret == 0 && prefix_data && prefix_len > 0) {
+				parent_prefix = xmalloc(prefix_len + 1);
+				if (parent_prefix) {
+					memcpy(parent_prefix, prefix_data, prefix_len);
+					parent_prefix[prefix_len] = '\0';
+				}
+			}
+			if (prefix_data)
+				free(prefix_data);
+
+			if (parent_prefix) {
+				pr_info("page-xfer: using parent prefix: %s\n", parent_prefix);
+				saved_prefix = opts.object_storage_object_prefix;
+				opts.object_storage_object_prefix = parent_prefix;
+				ret = open_page_read_at(pfd, img_id, xfer->parent, pr_flags);
+				opts.object_storage_object_prefix = saved_prefix;
+				xfree(parent_prefix);
+			} else {
+				ret = open_page_read_at(pfd, img_id, xfer->parent, pr_flags);
+			}
+		} else {
+			ret = open_page_read_at(pfd, img_id, xfer->parent, pr_flags);
+		}
+
 		if (ret <= 0) {
 			pr_perror("No parent image found, though parent directory is set");
 			xfree(xfer->parent);

--- a/criu/page-xfer.c
+++ b/criu/page-xfer.c
@@ -435,102 +435,88 @@ err_pmi:
 
 #define OBJECT_STORAGE_PART_SIZE (8 * 1024 * 1024) /* 8MB per multipart part */
 
+static int _flush_object_storage_part(struct page_xfer *xfer)
+{
+	char etag[256];
+	int ret;
+
+	if (xfer->object_storage.etags_count >= xfer->object_storage.etags_cap) {
+		int new_cap = xfer->object_storage.etags_cap * 2;
+		char **new_etags = xrealloc(xfer->object_storage.etags, new_cap * sizeof(char *));
+		if (!new_etags)
+			return -1;
+		xfer->object_storage.etags = new_etags;
+		xfer->object_storage.etags_cap = new_cap;
+	}
+
+	xfer->object_storage.part_number++;
+	ret = object_storage_multipart_upload_part(
+		xfer->object_storage.pages_key, xfer->object_storage.upload_id,
+		xfer->object_storage.part_number,
+		xfer->object_storage.part_buf, xfer->object_storage.part_buf_used,
+		etag, sizeof(etag));
+	if (ret < 0) {
+		pr_err("object_storage: multipart upload part %d failed\n",
+		       xfer->object_storage.part_number);
+		return -1;
+	}
+	xfer->object_storage.etags[xfer->object_storage.etags_count] = xstrdup(etag);
+	xfer->object_storage.etags_count++;
+	xfer->object_storage.part_buf_used = 0;
+	return 0;
+}
+
 static int write_pages_object_storage(struct page_xfer *xfer, int p, unsigned long len)
 {
 	unsigned long remaining;
 	ssize_t nread;
 	int ret;
 
-	/* First, write to local file via splice */
-	ret = write_pages_loc(xfer, p, len);
-	if (ret < 0)
-		return ret;
-
-	if (!xfer->object_storage.active)
-		return 0;
-
 	/*
-	 * Also read from the pages image we just wrote to buffer for S3 upload.
-	 * Since splice already consumed the pipe, we read back from the local
-	 * pages image file. Seek to the position before the splice.
+	 * Read pages from pipe directly into buffer for both local write
+	 * and object storage upload. We read from the pipe into a temp buffer,
+	 * write to local file, and accumulate in the part buffer for upload.
 	 */
-	{
-		off_t cur_pos;
-		void *read_buf;
+	remaining = len;
+	while (remaining > 0) {
+		unsigned long chunk_size;
+		unsigned long space;
+		char *dst;
 
-		cur_pos = lseek(img_raw_fd(xfer->pi), 0, SEEK_CUR);
-		if (cur_pos < 0 || (unsigned long)cur_pos < len) {
-			pr_err("object_storage: failed to seek back in pages image\n");
+		space = xfer->object_storage.part_buf_cap - xfer->object_storage.part_buf_used;
+		chunk_size = remaining < space ? remaining : space;
+
+		/* Read from pipe into part buffer */
+		dst = (char *)xfer->object_storage.part_buf + xfer->object_storage.part_buf_used;
+		nread = read(p, dst, chunk_size);
+		if (nread <= 0) {
+			pr_err("object_storage: failed to read from pipe\n");
 			return -1;
 		}
-		lseek(img_raw_fd(xfer->pi), cur_pos - len, SEEK_SET);
 
-		read_buf = xmalloc(len);
-		if (!read_buf)
-			return -1;
-
-		remaining = len;
-		while (remaining > 0) {
-			nread = read(img_raw_fd(xfer->pi), read_buf + (len - remaining), remaining);
-			if (nread <= 0) {
-				pr_err("object_storage: failed to read back pages data\n");
-				xfree(read_buf);
-				return -1;
-			}
-			remaining -= nread;
-		}
-
-		/* Seek back to end */
-		lseek(img_raw_fd(xfer->pi), cur_pos, SEEK_SET);
-
-		/* Accumulate in part buffer, flush when >= OBJECT_STORAGE_PART_SIZE */
+		/* Write to local pages file */
 		{
-			unsigned long src_off = 0;
-			while (src_off < len) {
-				unsigned long space = xfer->object_storage.part_buf_cap - xfer->object_storage.part_buf_used;
-				unsigned long to_copy = len - src_off;
-
-				if (to_copy > space)
-					to_copy = space;
-				memcpy((char *)xfer->object_storage.part_buf + xfer->object_storage.part_buf_used,
-				       (char *)read_buf + src_off, to_copy);
-				xfer->object_storage.part_buf_used += to_copy;
-				src_off += to_copy;
-
-				if (xfer->object_storage.part_buf_used >= OBJECT_STORAGE_PART_SIZE) {
-					char etag[256];
-
-					/* Grow etags array if needed */
-					if (xfer->object_storage.etags_count >= xfer->object_storage.etags_cap) {
-						int new_cap = xfer->object_storage.etags_cap * 2;
-						char **new_etags = xrealloc(xfer->object_storage.etags, new_cap * sizeof(char *));
-						if (!new_etags) {
-							xfree(read_buf);
-							return -1;
-						}
-						xfer->object_storage.etags = new_etags;
-						xfer->object_storage.etags_cap = new_cap;
-					}
-
-					xfer->object_storage.part_number++;
-					ret = object_storage_multipart_upload_part(
-						xfer->object_storage.pages_key, xfer->object_storage.upload_id,
-						xfer->object_storage.part_number,
-						xfer->object_storage.part_buf, xfer->object_storage.part_buf_used,
-						etag, sizeof(etag));
-					if (ret < 0) {
-						pr_err("object_storage: multipart upload part %d failed\n",
-						       xfer->object_storage.part_number);
-						xfree(read_buf);
-						return -1;
-					}
-					xfer->object_storage.etags[xfer->object_storage.etags_count] = xstrdup(etag);
-					xfer->object_storage.etags_count++;
-					xfer->object_storage.part_buf_used = 0;
+			ssize_t nw;
+			unsigned long wr = 0;
+			while (wr < (unsigned long)nread) {
+				nw = write(img_raw_fd(xfer->pi), dst + wr, nread - wr);
+				if (nw <= 0) {
+					pr_err("object_storage: failed to write to local pages file\n");
+					return -1;
 				}
+				wr += nw;
 			}
 		}
-		xfree(read_buf);
+
+		xfer->object_storage.part_buf_used += nread;
+		remaining -= nread;
+
+		/* Flush part when buffer is full */
+		if (xfer->object_storage.part_buf_used >= OBJECT_STORAGE_PART_SIZE) {
+			ret = _flush_object_storage_part(xfer);
+			if (ret < 0)
+				return ret;
+		}
 	}
 
 	return 0;
@@ -591,38 +577,60 @@ static void close_page_xfer_object_storage(struct page_xfer *xfer)
 				pr_err("object_storage: multipart complete failed for %s\n", xfer->object_storage.pages_key);
 		}
 
-		/* Upload pagemap from local file via put_object */
-		if (xfer->pmi) {
-			off_t pmi_size;
-			void *pmi_data;
-			int pmi_fd;
+		/*
+		 * Upload pagemap: close local files first to flush buffered writes,
+		 * then reopen the pagemap file to read and upload to object storage.
+		 */
+		{
+			char pagemap_key_copy[512];
+			snprintf(pagemap_key_copy, sizeof(pagemap_key_copy), "%s",
+				 xfer->object_storage.pagemap_key);
 
-			pmi_fd = img_raw_fd(xfer->pmi);
-			pmi_size = lseek(pmi_fd, 0, SEEK_END);
-			if (pmi_size > 0) {
-				ssize_t nr;
-				unsigned long rd;
+			/* Close local files (flushes buffers) */
+			close_page_xfer(xfer);
 
-				lseek(pmi_fd, 0, SEEK_SET);
-				pmi_data = xmalloc(pmi_size);
-				if (pmi_data) {
-					rd = 0;
-					while (rd < (unsigned long)pmi_size) {
-						nr = read(pmi_fd, (char *)pmi_data + rd, pmi_size - rd);
-						if (nr <= 0)
-							break;
-						rd += nr;
+			/* Reopen pagemap from images-dir and upload */
+			{
+				int pmi_fd;
+				off_t pmi_size;
+
+				pmi_fd = openat(get_service_fd(IMG_FD_OFF), pagemap_key_copy, O_RDONLY);
+				if (pmi_fd >= 0) {
+					pmi_size = lseek(pmi_fd, 0, SEEK_END);
+					if (pmi_size > 0) {
+						void *pmi_data;
+						ssize_t nr;
+						unsigned long rd;
+
+						lseek(pmi_fd, 0, SEEK_SET);
+						pmi_data = xmalloc(pmi_size);
+						if (pmi_data) {
+							rd = 0;
+							while (rd < (unsigned long)pmi_size) {
+								nr = read(pmi_fd, (char *)pmi_data + rd,
+									  pmi_size - rd);
+								if (nr <= 0)
+									break;
+								rd += nr;
+							}
+							if (rd == (unsigned long)pmi_size)
+								object_storage_put_object(pagemap_key_copy,
+											  pmi_data, pmi_size);
+							xfree(pmi_data);
+						}
 					}
-					if (rd == (unsigned long)pmi_size) {
-						object_storage_put_object(xfer->object_storage.pagemap_key,
-									  pmi_data, pmi_size);
-					}
-					xfree(pmi_data);
+					close(pmi_fd);
 				}
 			}
 		}
 
+		goto cleanup_storage;
+
 cleanup:
+		/* Close local files (if not already closed above) */
+		close_page_xfer(xfer);
+
+cleanup_storage:
 		/* Free etags */
 		for (i = 0; i < xfer->object_storage.etags_count; i++)
 			xfree(xfer->object_storage.etags[i]);
@@ -630,9 +638,6 @@ cleanup:
 		xfree(xfer->object_storage.part_buf);
 		xfer->object_storage.active = 0;
 	}
-
-	/* Close local files */
-	close_page_xfer(xfer);
 }
 
 static int open_page_object_storage_xfer(struct page_xfer *xfer, int fd_type, unsigned long img_id)
@@ -647,11 +652,25 @@ static int open_page_object_storage_xfer(struct page_xfer *xfer, int fd_type, un
 	/* Initialize object storage upload state */
 	memset(&xfer->object_storage, 0, sizeof(xfer->object_storage));
 
-	/* Construct S3 keys using the image filenames */
-	snprintf(xfer->object_storage.pages_key, sizeof(xfer->object_storage.pages_key),
-		 "pages-%lu.img", img_id);
-	snprintf(xfer->object_storage.pagemap_key, sizeof(xfer->object_storage.pagemap_key),
-		 "pagemap-%lu.img", img_id);
+	/*
+	 * Construct object storage keys from actual local filenames.
+	 * pages file uses sequential page_ids (1,2,3...), not PID.
+	 * pagemap file uses PID (img_id). Use path from cr_img if available.
+	 */
+	if (xfer->pi && xfer->pi->path) {
+		snprintf(xfer->object_storage.pages_key, sizeof(xfer->object_storage.pages_key),
+			 "%s", xfer->pi->path);
+	} else {
+		snprintf(xfer->object_storage.pages_key, sizeof(xfer->object_storage.pages_key),
+			 "pages-%lu.img", img_id);
+	}
+	if (xfer->pmi && xfer->pmi->path) {
+		snprintf(xfer->object_storage.pagemap_key, sizeof(xfer->object_storage.pagemap_key),
+			 "%s", xfer->pmi->path);
+	} else {
+		snprintf(xfer->object_storage.pagemap_key, sizeof(xfer->object_storage.pagemap_key),
+			 "pagemap-%lu.img", img_id);
+	}
 
 	/* Allocate part buffer */
 	xfer->object_storage.part_buf_cap = OBJECT_STORAGE_PART_SIZE;

--- a/criu/page-xfer.c
+++ b/criu/page-xfer.c
@@ -18,6 +18,7 @@
 #include "image.h"
 #include "page-xfer.h"
 #include "page-pipe.h"
+#include "object-storage.h"
 #include "util.h"
 #include "protobuf.h"
 #include "images/pagemap.pb-c.h"
@@ -426,6 +427,271 @@ err_pmi:
 	return -1;
 }
 
+/*
+ * S3 upload wrapper functions (dual-write: local + S3).
+ * Local xfer functions handle the actual file I/O.
+ * S3 functions upload pages data via multipart and pagemap via put_object.
+ */
+
+#define S3_PART_SIZE (8 * 1024 * 1024) /* 8MB per multipart part */
+
+static int write_pages_s3(struct page_xfer *xfer, int p, unsigned long len)
+{
+	unsigned long remaining;
+	ssize_t nread;
+	int ret;
+
+	/* First, write to local file via splice */
+	ret = write_pages_loc(xfer, p, len);
+	if (ret < 0)
+		return ret;
+
+	if (!xfer->s3.active)
+		return 0;
+
+	/*
+	 * Also read from the pages image we just wrote to buffer for S3 upload.
+	 * Since splice already consumed the pipe, we read back from the local
+	 * pages image file. Seek to the position before the splice.
+	 */
+	{
+		off_t cur_pos;
+		void *read_buf;
+
+		cur_pos = lseek(img_raw_fd(xfer->pi), 0, SEEK_CUR);
+		if (cur_pos < 0 || (unsigned long)cur_pos < len) {
+			pr_err("S3: failed to seek back in pages image\n");
+			return -1;
+		}
+		lseek(img_raw_fd(xfer->pi), cur_pos - len, SEEK_SET);
+
+		read_buf = xmalloc(len);
+		if (!read_buf)
+			return -1;
+
+		remaining = len;
+		while (remaining > 0) {
+			nread = read(img_raw_fd(xfer->pi), read_buf + (len - remaining), remaining);
+			if (nread <= 0) {
+				pr_err("S3: failed to read back pages data\n");
+				xfree(read_buf);
+				return -1;
+			}
+			remaining -= nread;
+		}
+
+		/* Seek back to end */
+		lseek(img_raw_fd(xfer->pi), cur_pos, SEEK_SET);
+
+		/* Accumulate in part buffer, flush when >= S3_PART_SIZE */
+		{
+			unsigned long src_off = 0;
+			while (src_off < len) {
+				unsigned long space = xfer->s3.part_buf_cap - xfer->s3.part_buf_used;
+				unsigned long to_copy = len - src_off;
+
+				if (to_copy > space)
+					to_copy = space;
+				memcpy((char *)xfer->s3.part_buf + xfer->s3.part_buf_used,
+				       (char *)read_buf + src_off, to_copy);
+				xfer->s3.part_buf_used += to_copy;
+				src_off += to_copy;
+
+				if (xfer->s3.part_buf_used >= S3_PART_SIZE) {
+					char etag[256];
+
+					/* Grow etags array if needed */
+					if (xfer->s3.etags_count >= xfer->s3.etags_cap) {
+						int new_cap = xfer->s3.etags_cap * 2;
+						char **new_etags = xrealloc(xfer->s3.etags, new_cap * sizeof(char *));
+						if (!new_etags) {
+							xfree(read_buf);
+							return -1;
+						}
+						xfer->s3.etags = new_etags;
+						xfer->s3.etags_cap = new_cap;
+					}
+
+					xfer->s3.part_number++;
+					ret = object_storage_multipart_upload_part(
+						xfer->s3.pages_key, xfer->s3.upload_id,
+						xfer->s3.part_number,
+						xfer->s3.part_buf, xfer->s3.part_buf_used,
+						etag, sizeof(etag));
+					if (ret < 0) {
+						pr_err("S3: multipart upload part %d failed\n",
+						       xfer->s3.part_number);
+						xfree(read_buf);
+						return -1;
+					}
+					xfer->s3.etags[xfer->s3.etags_count] = xstrdup(etag);
+					xfer->s3.etags_count++;
+					xfer->s3.part_buf_used = 0;
+				}
+			}
+		}
+		xfree(read_buf);
+	}
+
+	return 0;
+}
+
+static int write_pagemap_s3(struct page_xfer *xfer, struct iovec *iov, u32 flags)
+{
+	/* Write to local file first */
+	return write_pagemap_loc(xfer, iov, flags);
+	/* Pagemap is uploaded on close via put_object from the local file */
+}
+
+static void close_page_xfer_s3(struct page_xfer *xfer)
+{
+	int i;
+
+	if (xfer->s3.active) {
+		/* Flush remaining part buffer */
+		if (xfer->s3.part_buf_used > 0 || xfer->s3.part_number == 0) {
+			char etag[256];
+			int ret;
+
+			if (xfer->s3.etags_count >= xfer->s3.etags_cap) {
+				int new_cap = xfer->s3.etags_cap + 1;
+				char **new_etags = xrealloc(xfer->s3.etags, new_cap * sizeof(char *));
+				if (new_etags) {
+					xfer->s3.etags = new_etags;
+					xfer->s3.etags_cap = new_cap;
+				}
+			}
+
+			if (xfer->s3.part_buf_used > 0 || xfer->s3.part_number == 0) {
+				xfer->s3.part_number++;
+				ret = object_storage_multipart_upload_part(
+					xfer->s3.pages_key, xfer->s3.upload_id,
+					xfer->s3.part_number,
+					xfer->s3.part_buf,
+					xfer->s3.part_buf_used > 0 ? xfer->s3.part_buf_used : 0,
+					etag, sizeof(etag));
+				if (ret < 0) {
+					pr_err("S3: final part upload failed, aborting\n");
+					object_storage_multipart_abort(xfer->s3.pages_key,
+								       xfer->s3.upload_id);
+					goto cleanup;
+				}
+				xfer->s3.etags[xfer->s3.etags_count] = xstrdup(etag);
+				xfer->s3.etags_count++;
+			}
+		}
+
+		/* Complete multipart upload */
+		if (xfer->s3.etags_count > 0) {
+			int ret;
+			ret = object_storage_multipart_complete(
+				xfer->s3.pages_key, xfer->s3.upload_id,
+				xfer->s3.etags_count, (const char **)xfer->s3.etags);
+			if (ret < 0)
+				pr_err("S3: multipart complete failed for %s\n", xfer->s3.pages_key);
+		}
+
+		/* Upload pagemap from local file via put_object */
+		if (xfer->pmi) {
+			off_t pmi_size;
+			void *pmi_data;
+			int pmi_fd;
+
+			pmi_fd = img_raw_fd(xfer->pmi);
+			pmi_size = lseek(pmi_fd, 0, SEEK_END);
+			if (pmi_size > 0) {
+				ssize_t nr;
+				unsigned long rd;
+
+				lseek(pmi_fd, 0, SEEK_SET);
+				pmi_data = xmalloc(pmi_size);
+				if (pmi_data) {
+					rd = 0;
+					while (rd < (unsigned long)pmi_size) {
+						nr = read(pmi_fd, (char *)pmi_data + rd, pmi_size - rd);
+						if (nr <= 0)
+							break;
+						rd += nr;
+					}
+					if (rd == (unsigned long)pmi_size) {
+						object_storage_put_object(xfer->s3.pagemap_key,
+									  pmi_data, pmi_size);
+					}
+					xfree(pmi_data);
+				}
+			}
+		}
+
+cleanup:
+		/* Free etags */
+		for (i = 0; i < xfer->s3.etags_count; i++)
+			xfree(xfer->s3.etags[i]);
+		xfree(xfer->s3.etags);
+		xfree(xfer->s3.part_buf);
+		xfer->s3.active = 0;
+	}
+
+	/* Close local files */
+	close_page_xfer(xfer);
+}
+
+static int open_page_s3_xfer(struct page_xfer *xfer, int fd_type, unsigned long img_id)
+{
+	int ret;
+
+	/* First, open local xfer as usual */
+	ret = open_page_local_xfer(xfer, fd_type, img_id);
+	if (ret < 0)
+		return ret;
+
+	/* Initialize S3 upload state */
+	memset(&xfer->s3, 0, sizeof(xfer->s3));
+
+	/* Construct S3 keys using the image filenames */
+	snprintf(xfer->s3.pages_key, sizeof(xfer->s3.pages_key),
+		 "pages-%lu.img", img_id);
+	snprintf(xfer->s3.pagemap_key, sizeof(xfer->s3.pagemap_key),
+		 "pagemap-%lu.img", img_id);
+
+	/* Allocate part buffer */
+	xfer->s3.part_buf_cap = S3_PART_SIZE;
+	xfer->s3.part_buf = xmalloc(S3_PART_SIZE);
+	if (!xfer->s3.part_buf)
+		return -1;
+	xfer->s3.part_buf_used = 0;
+	xfer->s3.part_number = 0;
+
+	/* Allocate etags array */
+	xfer->s3.etags_cap = 64;
+	xfer->s3.etags = xmalloc(xfer->s3.etags_cap * sizeof(char *));
+	if (!xfer->s3.etags) {
+		xfree(xfer->s3.part_buf);
+		return -1;
+	}
+	xfer->s3.etags_count = 0;
+
+	/* Initiate multipart upload for pages */
+	ret = object_storage_multipart_init(xfer->s3.pages_key,
+					    xfer->s3.upload_id,
+					    sizeof(xfer->s3.upload_id));
+	if (ret < 0) {
+		pr_err("S3: failed to initiate multipart upload for %s\n",
+		       xfer->s3.pages_key);
+		xfree(xfer->s3.part_buf);
+		xfree(xfer->s3.etags);
+		return -1;
+	}
+
+	xfer->s3.active = 1;
+
+	/* Override write/close functions with S3 wrappers */
+	xfer->write_pagemap = write_pagemap_s3;
+	xfer->write_pages = write_pages_s3;
+	xfer->close = close_page_xfer_s3;
+
+	return 0;
+}
+
 int open_page_xfer(struct page_xfer *xfer, int fd_type, unsigned long img_id)
 {
 	xfer->offset = 0;
@@ -433,6 +699,8 @@ int open_page_xfer(struct page_xfer *xfer, int fd_type, unsigned long img_id)
 
 	if (opts.use_page_server)
 		return open_page_server_xfer(xfer, fd_type, img_id);
+	else if (opts.object_storage_upload)
+		return open_page_s3_xfer(xfer, fd_type, img_id);
 	else
 		return open_page_local_xfer(xfer, fd_type, img_id);
 }

--- a/criu/page-xfer.c
+++ b/criu/page-xfer.c
@@ -359,8 +359,10 @@ static void close_page_xfer(struct page_xfer *xfer)
 		xfree(xfer->parent);
 		xfer->parent = NULL;
 	}
-	close_image(xfer->pi);
-	close_image(xfer->pmi);
+	if (xfer->pi)
+		close_image(xfer->pi);
+	if (xfer->pmi)
+		close_image(xfer->pmi);
 }
 
 static int open_page_local_xfer(struct page_xfer *xfer, int fd_type, unsigned long img_id)
@@ -494,8 +496,8 @@ static int write_pages_object_storage(struct page_xfer *xfer, int p, unsigned lo
 			return -1;
 		}
 
-		/* Write to local pages file */
-		{
+		/* Write to local pages file (skip in S3-only mode) */
+		if (xfer->pi) {
 			ssize_t nw;
 			unsigned long wr = 0;
 			while (wr < (unsigned long)nread) {
@@ -644,7 +646,11 @@ static int open_page_object_storage_xfer(struct page_xfer *xfer, int fd_type, un
 {
 	int ret;
 
-	/* First, open local xfer as usual */
+	/*
+	 * Open local xfer first (creates pagemap + pages files locally).
+	 * We need local pagemap for pb_write_one() buffering.
+	 * Pages file is only needed in dual-write mode.
+	 */
 	ret = open_page_local_xfer(xfer, fd_type, img_id);
 	if (ret < 0)
 		return ret;
@@ -670,6 +676,16 @@ static int open_page_object_storage_xfer(struct page_xfer *xfer, int fd_type, un
 	} else {
 		snprintf(xfer->object_storage.pagemap_key, sizeof(xfer->object_storage.pagemap_key),
 			 "pagemap-%lu.img", img_id);
+	}
+
+	/*
+	 * Close local pages file — pages data goes only to object storage.
+	 * This eliminates disk I/O for the bulk data (pages are 99%+ of size).
+	 * Pagemap stays local for pb_write_one() buffering, uploaded on close.
+	 */
+	if (xfer->pi) {
+		close_image(xfer->pi);
+		xfer->pi = NULL;
 	}
 
 	/* Allocate part buffer */

--- a/criu/pagemap.c
+++ b/criu/pagemap.c
@@ -479,12 +479,14 @@ static int maybe_read_page_object_storage(struct page_read *pr, unsigned long va
 	pr_info("Object Storage: Reading %d pages (len: %lu) from %s at offset %lu for vaddr %lx\n",
 	        nr, len, image_name, pr->pi_off, vaddr);
 
-	/* Construct the object key with prefix if available */
-	if (opts.object_storage_object_prefix && strlen(opts.object_storage_object_prefix) > 0) {
-		snprintf(object_key, sizeof(object_key), "%s%s",
-		         opts.object_storage_object_prefix, image_name);
-	} else {
-		snprintf(object_key, sizeof(object_key), "%s", image_name);
+	/* Construct the object key: use per-page_read prefix if set, else global */
+	{
+		const char *prefix = pr->object_storage_prefix ? pr->object_storage_prefix : opts.object_storage_object_prefix;
+		if (prefix && strlen(prefix) > 0) {
+			snprintf(object_key, sizeof(object_key), "%s%s", prefix, image_name);
+		} else {
+			snprintf(object_key, sizeof(object_key), "%s", image_name);
+		}
 	}
 
 	/* Fetch data from object storage */
@@ -699,11 +701,93 @@ static int try_open_parent(int dfd, unsigned long id, struct page_read *pr, int 
 	if (pfd < 0) {
 		/*
 		 * No local parent directory. If object storage is enabled,
-		 * skip parent — the current image's pagemap and pages will
-		 * be fetched from S3 via do_open_image() fallback and
-		 * maybe_read_page_object_storage() respectively.
-		 * Parent chain resolution is not needed when all data is on S3.
+		 * try to fetch parent-prefix marker from S3 and set up
+		 * parent page_read with the parent's S3 prefix.
 		 */
+		if (opts.enable_object_storage) {
+			void *prefix_data = NULL;
+			unsigned long prefix_len = 0;
+			int s3_ret;
+			char *parent_prefix;
+			char *tmpdir;
+			int tfd;
+
+			s3_ret = object_storage_get_object("parent-prefix",
+							   &prefix_data, &prefix_len);
+			if (s3_ret != 0 || !prefix_data || prefix_len == 0) {
+				if (prefix_data)
+					free(prefix_data);
+				pr_debug("No parent-prefix on S3, no parent chain\n");
+				goto out;
+			}
+
+			/* Null-terminate the prefix */
+			parent_prefix = xmalloc(prefix_len + 1);
+			if (!parent_prefix) {
+				free(prefix_data);
+				goto out;
+			}
+			memcpy(parent_prefix, prefix_data, prefix_len);
+			parent_prefix[prefix_len] = '\0';
+			free(prefix_data);
+
+			pr_info("Found parent prefix on S3: %s\n", parent_prefix);
+
+			/*
+			 * Create a tmpdir and fetch parent metadata from S3.
+			 * We temporarily swap the global prefix to parent prefix,
+			 * open page_read (which triggers S3 fallback for metadata),
+			 * then restore the original prefix.
+			 */
+			tmpdir = xstrdup("/tmp/criu-parent-XXXXXX");
+			if (!tmpdir || !mkdtemp(tmpdir)) {
+				xfree(parent_prefix);
+				xfree(tmpdir);
+				goto out;
+			}
+
+			tfd = open(tmpdir, O_RDONLY | O_DIRECTORY);
+			if (tfd < 0) {
+				xfree(parent_prefix);
+				xfree(tmpdir);
+				goto out;
+			}
+
+			parent = xmalloc(sizeof(*parent));
+			if (!parent) {
+				close(tfd);
+				xfree(parent_prefix);
+				xfree(tmpdir);
+				goto out;
+			}
+
+			/* Swap prefix to parent's, open page_read, restore */
+			{
+				char *saved_prefix = opts.object_storage_object_prefix;
+				opts.object_storage_object_prefix = parent_prefix;
+				ret = open_page_read_at(tfd, id, parent, pr_flags);
+				opts.object_storage_object_prefix = saved_prefix;
+			}
+
+			close(tfd);
+
+			if (ret <= 0) {
+				pr_debug("Could not open parent page_read from S3\n");
+				xfree(parent);
+				parent = NULL;
+			} else {
+				/* Set per-page_read prefix for parent pages fetch */
+				parent->object_storage_prefix = parent_prefix;
+				parent_prefix = NULL; /* ownership transferred */
+			}
+
+			if (parent_prefix)
+				xfree(parent_prefix);
+
+			/* Clean up tmpdir (files are in memfd, not on disk) */
+			rmdir(tmpdir);
+			xfree(tmpdir);
+		}
 		goto out;
 	}
 
@@ -849,6 +933,7 @@ int open_page_read_at(int dfd, unsigned long img_id, struct page_read *pr, int p
 	INIT_LIST_HEAD(&pr->async);
 	pr->pe = NULL;
 	pr->parent = NULL;
+	pr->object_storage_prefix = NULL;
 	pr->cvaddr = 0;
 	pr->pi_off = 0;
 	pr->bunch.iov_len = 0;

--- a/criu/pagemap.c
+++ b/criu/pagemap.c
@@ -696,8 +696,16 @@ static int try_open_parent(int dfd, unsigned long id, struct page_read *pr, int 
 
 	if (open_parent(dfd, &pfd))
 		goto err;
-	if (pfd < 0)
+	if (pfd < 0) {
+		/*
+		 * No local parent directory. If object storage is enabled,
+		 * skip parent — the current image's pagemap and pages will
+		 * be fetched from S3 via do_open_image() fallback and
+		 * maybe_read_page_object_storage() respectively.
+		 * Parent chain resolution is not needed when all data is on S3.
+		 */
 		goto out;
+	}
 
 	parent = xmalloc(sizeof(*parent));
 	if (!parent)

--- a/criu/pagemap.c
+++ b/criu/pagemap.c
@@ -700,7 +700,41 @@ static int try_open_parent(int dfd, unsigned long id, struct page_read *pr, int 
 		goto err;
 	if (pfd < 0) {
 		/*
-		 * No local parent directory. If object storage is enabled,
+		 * No local parent symlink. Try to reconstruct from
+		 * parent-prefix file (present when downloaded from S3).
+		 */
+		int ppfd;
+		ppfd = openat(dfd, "parent-prefix", O_RDONLY);
+		if (ppfd >= 0) {
+			char pp_buf[1024];
+			ssize_t nr;
+			nr = read(ppfd, pp_buf, sizeof(pp_buf) - 1);
+			close(ppfd);
+			if (nr > 0) {
+				char *last_slash;
+				char *dir_name;
+				char symtgt[1024];
+
+				pp_buf[nr] = '\0';
+				while (nr > 0 && (pp_buf[nr-1] == '/' || pp_buf[nr-1] == '\n'))
+					pp_buf[--nr] = '\0';
+				last_slash = strrchr(pp_buf, '/');
+				dir_name = last_slash ? last_slash + 1 : pp_buf;
+				snprintf(symtgt, sizeof(symtgt), "../%.1020s", dir_name);
+
+				if (faccessat(dfd, symtgt, R_OK, 0) == 0) {
+					if (symlinkat(symtgt, dfd, CR_PARENT_LINK) == 0 || errno == EEXIST) {
+						pr_info("Reconstructed parent symlink in sub-dir: %s\n", symtgt);
+						/* Retry open_parent */
+						if (open_parent(dfd, &pfd) == 0 && pfd >= 0)
+							goto have_parent;
+					}
+				}
+			}
+		}
+
+		/*
+		 * Still no parent. If object storage is enabled,
 		 * try to fetch parent-prefix marker from S3 and set up
 		 * parent page_read with the parent's S3 prefix.
 		 */
@@ -791,6 +825,7 @@ static int try_open_parent(int dfd, unsigned long id, struct page_read *pr, int 
 		goto out;
 	}
 
+have_parent:
 	parent = xmalloc(sizeof(*parent));
 	if (!parent)
 		goto err_cl;


### PR DESCRIPTION
## Summary
- CRIU checkpoint image를 local disk staging 없이 object storage에 직접 upload하는 기능 추가
- `--object-storage-upload` CLI option으로 활성화
- S3-only 모드: local disk I/O 완전 제거 (memfd 사용)
- Pre-dump chain의 parent resolution을 object storage에서 처리
- Restore 시 parent symlink 자동 재구성

## Changes (13 commits)
1. SigV4 리팩터링: GET 전용 → 모든 HTTP method 지원
2. `object_storage_put_object()`: metadata upload (Simple PUT)
3. Multipart Upload API: pages-*.img 대용량 파일 (8MB parts)
4. `object_storage_get_object()`: metadata fetch (전체 파일 다운로드)
5. `--object-storage-upload` CLI option
6. page-xfer S3 write backend: pipe → buffer → S3 multipart
7. Metadata dual-write: close_image() 시 S3 upload
8. Metadata S3 fallback: open 시 ENOENT → S3 fetch → memfd
9. S3-only 모드: memfd로 zero disk I/O
10. Parent chain S3 resolution + object_storage 네이밍 통일
11. cr_img.path 초기화 수정 (restore crash fix)
12. Pages 파일명 수정 (pages-1.img 일치)
13. AWS S3 SigV4 호환 (content-length signed headers 제거)

## B_eff = B_net
Azure instance에서 uncached disk throughput (96-384 MB/s)이 network (156-500 MB/s)보다 낮아 disk가 bottleneck. Direct upload으로 disk staging 제거 → B_eff = B_net.

## Test
- MinIO (path-style): dump + restore ✅
- QEMU VM: counter process dump → S3 download → restore (counter 계속 증가) ✅
- QEMU VM: pre-dump chain (3-level) → S3 download → parent symlink 자동 재구성 → restore ✅
- QEMU VM: increase_memory.py → pre-dump chain → restore ✅
- AWS S3 (us-west-2, virtual-hosted): 13개 파일 upload ✅
- S3-only mode: local images-dir 완전 비어있음 ✅

## LOC
~1,100 lines added across object-storage.c, page-xfer.c, image.c, pagemap.c

🤖 Generated with [Claude Code](https://claude.com/claude-code)