### PR TITLE
fault-skip-readahead: skip 16 MB ra_buf refill in UFFD fault path

### DIFF
--- a/criu/pagemap.c
+++ b/criu/pagemap.c
@@ -1307,7 +1307,19 @@ static int maybe_read_page_object_storage(struct page_read *pr, unsigned long va
 	 * is created on the local filesystem; the buffer lives only as
 	 * long as this page_read.
 	 */
-	if (pr->ra_cap > 0) {
+	/*
+	 * Read-ahead is intended for cr-restore's eager pagemap walk,
+	 * which issues many small sequential reads against pages-N.img.
+	 * The lazy-pages daemon's UFFD fault path is the opposite: each
+	 * fault asks for one IOV (typically a few KB) at a non-monotonic
+	 * offset, so a 16 MB ra_buf refill becomes a 16 MB Range GET that
+	 * the fault thread waits on. Across-region per-stream throughput
+	 * (~0.7 MB/s observed) makes that wait dominate cr-restore wall
+	 * time when many threads each fault once during pie restore. Skip
+	 * ra_buf in the fault path and serve via the exact-size direct
+	 * fetch below.
+	 */
+	if (pr->ra_cap > 0 && !(flags & PR_FAULT)) {
 		off_t hit_lo = pr->pi_off;
 		off_t hit_hi = pr->pi_off + (off_t)len;
 


### PR DESCRIPTION
## Summary

- The 16 MB read-ahead window in `maybe_read_page_object_storage()` was sized for cr-restore's eager pagemap walk (many small sequential reads). The lazy-pages daemon's UFFD fault path uses the same function but with the opposite access pattern: one IOV per fault (typically 8–12 KB) at a non-monotonic offset.
- Across regions (~134 ms RTT, ~0.7 MB/s per stream) every fault turned into a 16 MB Range GET that the fault thread waited on (≈ 23 s per fault). On ml-training (47 OpenMP threads each faulting once during pie restore) this serialized to **47 × 23 s = 1080 s** of cr-restore wall time.
- Gating `ra_buf` on `!(flags & PR_FAULT)` routes fault reads through the exact-size `direct_fetch` path. Eager pagemap walk and worker prefetch are unchanged.

## Verification

Tested on eu-west-3 ml-training v3 dst against us-west-2 S3:

| | rest (cr-restore wall) | faults | daemon |
|---|---|---|---|
| Pre-fix | **1080.5 s** | 272 | 791 s |
| **Fix** | **29.6 s** | 387 | 799 s |

- cr-restore wall: 97.3% reduction
- per-fault delta: 23 s → 0.15 s
- daemon background throughput unchanged (independent issue)
- ml-training restore now matches other 8 GB workloads (mc-8gb 22 s, redis 26 s)

## Test plan

- [x] Verify fix on cross-region ml-training (1 rep)
- [x] Confirm baseline (eager) mode unaffected (5.04 s)
- [ ] Phase A v4 measurement (9 workloads × 5 reps × {raw baseline, compressed ours}) once merged + AMI rebuilt

## Notes

Two follow-up improvements were attempted on top of this fix and discarded:
1. **Async fault dispatch** (handle_page_fault → worker pool dispatch): only 2 s additional saving (pie restorer's futex barriers are the next bottleneck), did not justify ~125 LoC + race-condition risk.
2. **Remove 256 KB pre-queue size filter**: passed local single-thread smoke test but reproduced a multi-thread hang on ml-training (cr-restore stuck after thread Restored, no Tasks resumed). Likely small-IOV vs lpi->iovs reap mismatch — needs proper invariant audit before retrying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)