### PR TITLE
obstor_prefetch + object-storage: short-circuit GET/HEAD via LIST cache

### DIFF
--- a/criu/include/object-storage.h
+++ b/criu/include/object-storage.h
@@ -194,11 +194,14 @@ int object_storage_head_object(const char *object_key, unsigned long *out_length
  * Handles pagination; returned keys are all under the given prefix.
  *
  * On success: *out_keys is an xmalloc'd array of xstrdup'd key strings,
- * *out_n is the count. Caller must xfree each key and free() the array.
+ * *out_sizes (if non-NULL) is a parallel realloc'd array of byte sizes from
+ * the LIST <Size> field, *out_n is the count. Caller must xfree each key
+ * and free() both arrays. Pass out_sizes=NULL if sizes are not needed.
  *
  * Returns 0 on success, -1 on failure.
  */
-int object_storage_list_objects(const char *key_prefix, char ***out_keys, size_t *out_n);
+int object_storage_list_objects(const char *key_prefix, char ***out_keys,
+				unsigned long **out_sizes, size_t *out_n);
 
 /*
  * Re-initialize the object-storage client after a fork (e.g. the lazy-pages

--- a/criu/include/obstor_prefetch.h
+++ b/criu/include/obstor_prefetch.h
@@ -52,6 +52,16 @@ int obstor_prefetch_init(int num_workers);
 int obstor_prefetch_lookup(const char *path, const void **out_data, size_t *out_len);
 
 /*
+ * Look up the LIST-reported byte size for `path`. Available for every key
+ * the LIST wave saw, including pages-*.img (which we don't fetch into the
+ * data cache). Lets HEAD short-circuit avoid a per-pages round-trip.
+ *
+ * On hit: *out_size set to the size from <Size>, returns 0.
+ * On miss: returns -1.
+ */
+int obstor_prefetch_lookup_size(const char *path, unsigned long *out_size);
+
+/*
  * True iff a previous obstor_prefetch_init() successfully LISTed and
  * populated the cache. If true, a lookup miss means the file does not
  * exist in object storage — callers can skip any sync fallback GET.

--- a/criu/object-storage.c
+++ b/criu/object-storage.c
@@ -25,6 +25,7 @@
 #include "log.h"
 #include "cr_options.h"
 #include "object-storage.h"
+#include "obstor_prefetch.h"
 #include "servicefd.h"
 #include "xmalloc.h"
 
@@ -3028,6 +3029,8 @@ int object_storage_get_object(const char *object_key, void **out_data, unsigned 
 	CURLcode res;
 	long http_code = 0;
 	struct curl_slist *headers = NULL;
+	const void *cache_data = NULL;
+	size_t cache_len = 0;
 
 	if (!object_key || !out_data || !out_length) {
 		pr_err("get_object: NULL parameter\n");
@@ -3036,6 +3039,33 @@ int object_storage_get_object(const char *object_key, void **out_data, unsigned 
 
 	*out_data = NULL;
 	*out_length = 0;
+
+	/*
+	 * Short-circuit via the metadata prefetch cache. obstor_prefetch_init
+	 * LISTed the active prefix (and its parent chain) and fetched every
+	 * non-pages key in parallel, so the cache mirrors the set of objects
+	 * that exist on S3 under this prefix. A miss on an authoritative cache
+	 * means the object truly doesn't exist — no point burning a 134ms
+	 * cross-region 404. Most visibly this kills the per-page_read GET of
+	 * "parent-prefix" on full dumps (called from open_page_xfer,
+	 * try_open_parent_at, get_parent_inventory).
+	 */
+	if (obstor_prefetch_lookup(object_key, &cache_data, &cache_len) == 0) {
+		void *copy = malloc(cache_len);
+		if (!copy)
+			return -1;
+		memcpy(copy, cache_data, cache_len);
+		*out_data = copy;
+		*out_length = cache_len;
+		pr_debug("GET %s: %lu bytes (prefetch cache hit)\n", object_key,
+			 (unsigned long)cache_len);
+		return 0;
+	}
+	if (obstor_prefetch_is_authoritative()) {
+		pr_debug("GET %s: skipped (prefetch cache authoritative miss)\n",
+			 object_key);
+		return -ENOENT;
+	}
 
 	if (opts.express_one_zone) {
 		if (ensure_valid_session() != 0)
@@ -3116,6 +3146,7 @@ int object_storage_head_object(const char *object_key, unsigned long *out_length
 	long http_code = 0;
 	curl_off_t content_length = -1;
 	struct curl_slist *headers = NULL;
+	unsigned long cached_size = 0;
 
 	if (!object_key || !out_length) {
 		pr_err("head_object: NULL parameter\n");
@@ -3123,6 +3154,25 @@ int object_storage_head_object(const char *object_key, unsigned long *out_length
 	}
 
 	*out_length = 0;
+
+	/*
+	 * Short-circuit via the prefetch size cache. obstor_prefetch_init
+	 * pulled <Size> out of the LIST response for every key in the active
+	 * prefix (including pages-*.img we don't download), so we can answer
+	 * HEAD directly without a cross-region round-trip. Authoritative miss
+	 * still returns -ENOENT so existence semantics match the real HEAD.
+	 */
+	if (obstor_prefetch_lookup_size(object_key, &cached_size) == 0) {
+		*out_length = cached_size;
+		pr_debug("HEAD %s: %lu bytes (prefetch size cache hit)\n",
+			 object_key, cached_size);
+		return 0;
+	}
+	if (obstor_prefetch_is_authoritative()) {
+		pr_debug("HEAD %s: skipped (prefetch cache authoritative miss)\n",
+			 object_key);
+		return -ENOENT;
+	}
 
 	if (opts.express_one_zone) {
 		if (ensure_valid_session() != 0)
@@ -3260,7 +3310,8 @@ static int _xml_extract_next(const char **cursor, const char *end, const char *t
  * Returns 0 on success, -1 on failure.
  */
 static int _list_objects_v2_once(const char *key_prefix, const char *continuation_in,
-				 char ***io_keys, size_t *io_n, size_t *io_cap,
+				 char ***io_keys, unsigned long **io_sizes,
+				 size_t *io_n, size_t *io_cap,
 				 char **continuation_out)
 {
 	struct object_url_info url_info_unused;
@@ -3278,7 +3329,6 @@ static int _list_objects_v2_once(const char *key_prefix, const char *continuatio
 	const char *endpoint_url, *hostname;
 	const char *cursor, *end_p;
 	char truncated_buf[16];
-	char key_buf[2048];
 	int ret = -1;
 
 	(void)url_info_unused;
@@ -3393,21 +3443,85 @@ static int _list_objects_v2_once(const char *key_prefix, const char *continuatio
 		goto out;
 	}
 
-	/* Parse XML: extract all <Key> and optional <NextContinuationToken>. */
+	/*
+	 * Parse XML by walking <Contents>...</Contents> blocks, extracting
+	 * <Key> and <Size> from each. Doing this per-block (rather than
+	 * separate sequential walks for Key and Size) keeps the pairing
+	 * unambiguous if S3 ever changes the relative order.
+	 */
 	cursor = (const char *)chunk.memory;
 	end_p = cursor + chunk.size;
-	while (_xml_extract_next(&cursor, end_p, "Key", key_buf, sizeof(key_buf)) == 0) {
+	for (;;) {
+		const char *contents_open;
+		const char *contents_close;
+		const char *kp, *kq;
+		const char *sp, *sq;
+		char key_buf[2048];
+		char size_buf[64];
+		unsigned long size_val = 0;
+		size_t key_len, size_len;
+
+		contents_open = strstr(cursor, "<Contents>");
+		if (!contents_open || contents_open >= end_p)
+			break;
+		contents_close = strstr(contents_open, "</Contents>");
+		if (!contents_close || contents_close >= end_p)
+			break;
+
+		kp = strstr(contents_open, "<Key>");
+		if (!kp || kp >= contents_close) {
+			cursor = contents_close + strlen("</Contents>");
+			continue;
+		}
+		kp += strlen("<Key>");
+		kq = strstr(kp, "</Key>");
+		if (!kq || kq >= contents_close) {
+			cursor = contents_close + strlen("</Contents>");
+			continue;
+		}
+		key_len = (size_t)(kq - kp);
+		if (key_len >= sizeof(key_buf))
+			key_len = sizeof(key_buf) - 1;
+		memcpy(key_buf, kp, key_len);
+		key_buf[key_len] = '\0';
+
+		sp = strstr(contents_open, "<Size>");
+		if (sp && sp < contents_close) {
+			sp += strlen("<Size>");
+			sq = strstr(sp, "</Size>");
+			if (sq && sq < contents_close) {
+				size_len = (size_t)(sq - sp);
+				if (size_len < sizeof(size_buf)) {
+					memcpy(size_buf, sp, size_len);
+					size_buf[size_len] = '\0';
+					size_val = strtoul(size_buf, NULL, 10);
+				}
+			}
+		}
+
 		if (*io_n == *io_cap) {
 			size_t new_cap = *io_cap ? (*io_cap) * 2 : 128;
 			char **nk = realloc(*io_keys, new_cap * sizeof(char *));
+			unsigned long *ns;
+
 			if (!nk) {
-				pr_err("list_objects: realloc failed\n");
+				pr_err("list_objects: realloc keys failed\n");
 				goto out;
 			}
 			*io_keys = nk;
+			ns = realloc(*io_sizes, new_cap * sizeof(unsigned long));
+			if (!ns) {
+				pr_err("list_objects: realloc sizes failed\n");
+				goto out;
+			}
+			*io_sizes = ns;
 			*io_cap = new_cap;
 		}
-		(*io_keys)[(*io_n)++] = xstrdup(key_buf);
+		(*io_keys)[*io_n] = xstrdup(key_buf);
+		(*io_sizes)[*io_n] = size_val;
+		(*io_n)++;
+
+		cursor = contents_close + strlen("</Contents>");
 	}
 
 	{
@@ -3428,13 +3542,17 @@ out:
 }
 
 /*
- * Enumerate all object keys under the given prefix.
- * On success: *out_keys points to an xmalloc'd array of xstrdup'd key strings,
- * *out_n is the count. Caller must xfree each key and the array.
+ * Enumerate all object keys under the given prefix, also returning their
+ * sizes (via the LIST <Size> field). On success: *out_keys is a parallel
+ * array of xstrdup'd key strings, *out_sizes is a realloc'd array of byte
+ * sizes, *out_n is the count. Caller must xfree each key, the keys array,
+ * and free() the sizes array. Pass out_sizes=NULL if sizes aren't needed.
  */
-int object_storage_list_objects(const char *key_prefix, char ***out_keys, size_t *out_n)
+int object_storage_list_objects(const char *key_prefix, char ***out_keys,
+				unsigned long **out_sizes, size_t *out_n)
 {
 	char **keys = NULL;
+	unsigned long *sizes = NULL;
 	size_t n = 0, cap = 0;
 	char *continuation = NULL;
 	int rounds = 0;
@@ -3442,11 +3560,14 @@ int object_storage_list_objects(const char *key_prefix, char ***out_keys, size_t
 	if (!out_keys || !out_n)
 		return -1;
 	*out_keys = NULL;
+	if (out_sizes)
+		*out_sizes = NULL;
 	*out_n = 0;
 
 	do {
 		char *next = NULL;
-		if (_list_objects_v2_once(key_prefix, continuation, &keys, &n, &cap, &next) != 0) {
+		if (_list_objects_v2_once(key_prefix, continuation, &keys, &sizes,
+					  &n, &cap, &next) != 0) {
 			if (continuation)
 				xfree(continuation);
 			goto err;
@@ -3462,11 +3583,17 @@ int object_storage_list_objects(const char *key_prefix, char ***out_keys, size_t
 	} while (continuation);
 
 	*out_keys = keys;
+	if (out_sizes)
+		*out_sizes = sizes;
+	else if (sizes)
+		free(sizes);
 	*out_n = n;
 	pr_info("LIST prefix='%s': %zu keys (%d page(s))\n", key_prefix ? key_prefix : "", n, rounds);
 	return 0;
 
 err:
+	if (sizes)
+		free(sizes);
 	if (keys) {
 		size_t i;
 		for (i = 0; i < n; i++)

--- a/criu/obstor_prefetch.c
+++ b/criu/obstor_prefetch.c
@@ -20,8 +20,9 @@
 
 struct cache_entry {
 	char *path;
-	void *data;
-	size_t len;
+	void *data;          /* NULL when only size is known (e.g. pages-*.img) */
+	size_t len;          /* 0 when data is NULL */
+	unsigned long size;  /* object size on S3 from LIST <Size> */
 	struct cache_entry *next;
 };
 
@@ -54,15 +55,94 @@ static unsigned long _path_hash(const char *s)
 	return h;
 }
 
-static int _cache_insert(const char *path, void *data, size_t len)
+/*
+ * Record the LIST-reported object size for `path`. Inserts a new size-only
+ * entry (data=NULL) when none exists, or updates the size on an existing
+ * entry. Used at LIST time before any data has been fetched, so HEAD
+ * short-circuit can find the size even for keys we don't download (e.g.
+ * pages-*.img).
+ */
+static int _cache_record_size(const char *path, unsigned long size)
 {
-	struct cache_entry *e;
+	struct cache_entry *e, *cur;
 	unsigned long bkt;
+
+	bkt = _path_hash(path) % OBSTOR_PREFETCH_BUCKETS;
+
+	pthread_mutex_lock(&g_cache_lock);
+	for (cur = g_cache[bkt]; cur; cur = cur->next) {
+		if (strcmp(cur->path, path) == 0) {
+			cur->size = size;
+			pthread_mutex_unlock(&g_cache_lock);
+			return 0;
+		}
+	}
+	pthread_mutex_unlock(&g_cache_lock);
 
 	e = xmalloc(sizeof(*e));
 	if (!e)
 		return -1;
+	e->path = xstrdup(path);
+	if (!e->path) {
+		xfree(e);
+		return -1;
+	}
+	e->data = NULL;
+	e->len = 0;
+	e->size = size;
 
+	pthread_mutex_lock(&g_cache_lock);
+	/* Re-check under lock to avoid duplicate insert under concurrency. */
+	for (cur = g_cache[bkt]; cur; cur = cur->next) {
+		if (strcmp(cur->path, path) == 0) {
+			cur->size = size;
+			pthread_mutex_unlock(&g_cache_lock);
+			xfree(e->path);
+			xfree(e);
+			return 0;
+		}
+	}
+	e->next = g_cache[bkt];
+	g_cache[bkt] = e;
+	g_cache_entries++;
+	pthread_mutex_unlock(&g_cache_lock);
+
+	return 0;
+}
+
+/*
+ * Record fetched object bytes for `path`. Updates an existing entry in
+ * place (typically the size-only entry inserted at LIST time) or inserts a
+ * new entry if none exists. Takes ownership of `data` on success.
+ */
+static int _cache_record_data(const char *path, void *data, size_t len)
+{
+	struct cache_entry *e;
+	unsigned long bkt;
+
+	bkt = _path_hash(path) % OBSTOR_PREFETCH_BUCKETS;
+
+	pthread_mutex_lock(&g_cache_lock);
+	for (e = g_cache[bkt]; e; e = e->next) {
+		if (strcmp(e->path, path) == 0) {
+			if (e->data) {
+				g_cache_bytes -= e->len;
+				free(e->data);
+			}
+			e->data = data;
+			e->len = len;
+			if (e->size == 0)
+				e->size = len;
+			g_cache_bytes += len;
+			pthread_mutex_unlock(&g_cache_lock);
+			return 0;
+		}
+	}
+	pthread_mutex_unlock(&g_cache_lock);
+
+	e = xmalloc(sizeof(*e));
+	if (!e)
+		return -1;
 	e->path = xstrdup(path);
 	if (!e->path) {
 		xfree(e);
@@ -70,8 +150,7 @@ static int _cache_insert(const char *path, void *data, size_t len)
 	}
 	e->data = data;
 	e->len = len;
-
-	bkt = _path_hash(path) % OBSTOR_PREFETCH_BUCKETS;
+	e->size = len;
 
 	pthread_mutex_lock(&g_cache_lock);
 	e->next = g_cache[bkt];
@@ -119,22 +198,74 @@ int obstor_prefetch_lookup(const char *path, const void **out_data, size_t *out_
 		return -1;
 
 	/*
-	 * Build the full key the same way we did at insert time:
-	 * normalize(opts.object_storage_object_prefix) + path. Using just
-	 * `path` (e.g., "inventory.img") is ambiguous when pre-dump chains
-	 * swap the active prefix — parent and child snapshots share
-	 * basenames but live under different S3 prefixes.
+	 * Build the full key the same way we did at insert time. Mirror the
+	 * convention used by _construct_object_url() in object-storage.c:
+	 * any key containing '/' is already absolute (e.g., probe keys built
+	 * as "<prefix>/pages-N.img"), bare filenames need the active prefix
+	 * prepended. Without this, full-path callers (HEAD / range probes)
+	 * always miss because we'd double up the prefix.
 	 */
-	_normalize_prefix(opts.object_storage_object_prefix, normalized, sizeof(normalized));
-	snprintf(full_key, sizeof(full_key), "%s%s", normalized, path);
+	if (strchr(path, '/')) {
+		snprintf(full_key, sizeof(full_key), "%s", path);
+	} else {
+		_normalize_prefix(opts.object_storage_object_prefix, normalized,
+				  sizeof(normalized));
+		snprintf(full_key, sizeof(full_key), "%s%s", normalized, path);
+	}
 
 	bkt = _path_hash(full_key) % OBSTOR_PREFETCH_BUCKETS;
 
 	pthread_mutex_lock(&g_cache_lock);
 	for (e = g_cache[bkt]; e; e = e->next) {
 		if (strcmp(e->path, full_key) == 0) {
+			/* Size-only entry: data not in cache (e.g. pages-*.img
+			 * skipped at fetch wave). Treat as miss for data lookup
+			 * so caller falls back to a real GET. Authoritative
+			 * miss check below still covers the doesn't-exist case. */
+			if (!e->data) {
+				pthread_mutex_unlock(&g_cache_lock);
+				return -1;
+			}
 			*out_data = e->data;
 			*out_len = e->len;
+			pthread_mutex_unlock(&g_cache_lock);
+			return 0;
+		}
+	}
+	pthread_mutex_unlock(&g_cache_lock);
+	return -1;
+}
+
+int obstor_prefetch_lookup_size(const char *path, unsigned long *out_size)
+{
+	struct cache_entry *e;
+	unsigned long bkt;
+	char normalized[512];
+	char full_key[1024];
+
+	if (!g_prefetch_initialized || !path || !out_size)
+		return -1;
+
+	/*
+	 * Mirror _construct_object_url(): keys with '/' are already absolute
+	 * (e.g., "<prefix>/pages-N.img" passed by init_s3_compression and the
+	 * lazy-pages compression probe), bare names get the prefix prepended.
+	 * Cache keys are always stored in absolute form.
+	 */
+	if (strchr(path, '/')) {
+		snprintf(full_key, sizeof(full_key), "%s", path);
+	} else {
+		_normalize_prefix(opts.object_storage_object_prefix, normalized,
+				  sizeof(normalized));
+		snprintf(full_key, sizeof(full_key), "%s%s", normalized, path);
+	}
+
+	bkt = _path_hash(full_key) % OBSTOR_PREFETCH_BUCKETS;
+
+	pthread_mutex_lock(&g_cache_lock);
+	for (e = g_cache[bkt]; e; e = e->next) {
+		if (strcmp(e->path, full_key) == 0) {
+			*out_size = e->size;
 			pthread_mutex_unlock(&g_cache_lock);
 			return 0;
 		}
@@ -268,7 +399,7 @@ static void *_prefetch_worker(void *arg)
 		rc = object_storage_get_object(item->stripped, &data, &len);
 
 		if (rc == 0 && data && len > 0) {
-			if (_cache_insert(item->full_key, data, len) != 0) {
+			if (_cache_record_data(item->full_key, data, len) != 0) {
 				pr_warn("cache insert failed for %s\n", item->full_key);
 				free(data);
 			}
@@ -296,6 +427,7 @@ static void *_prefetch_worker(void *arg)
 static int _prefetch_current_prefix(int num_workers, char *parent_prefix_out, size_t parent_cap)
 {
 	char **keys = NULL;
+	unsigned long *sizes = NULL;
 	size_t nkeys = 0, i;
 	struct work_queue wq;
 	pthread_t *tids = NULL;
@@ -311,14 +443,32 @@ static int _prefetch_current_prefix(int num_workers, char *parent_prefix_out, si
 	current_prefix = opts.object_storage_object_prefix ? opts.object_storage_object_prefix : "";
 	_normalize_prefix(current_prefix, normalized, sizeof(normalized));
 
-	if (object_storage_list_objects(current_prefix, &keys, &nkeys) != 0) {
+	if (object_storage_list_objects(current_prefix, &keys, &sizes, &nkeys) != 0) {
 		pr_err("LIST failed for prefix '%s'\n", current_prefix);
 		return -1;
 	}
 	if (nkeys == 0) {
 		pr_info("LIST returned 0 keys for prefix '%s'\n", current_prefix);
 		free(keys);
+		if (sizes)
+			free(sizes);
 		return 0;
+	}
+
+	/*
+	 * Record (key → size) for every LISTed key, including pages-*.img
+	 * which we don't fetch into the cache. Lets HEAD short-circuit
+	 * resolve sizes from the LIST result instead of paying a per-pages
+	 * round-trip in the compression-detection probe.
+	 */
+	for (i = 0; i < nkeys; i++) {
+		const char *stripped = _strip_prefix(keys[i], current_prefix);
+		char full_key[1024];
+
+		if (!stripped || !stripped[0])
+			continue;
+		snprintf(full_key, sizeof(full_key), "%s%s", normalized, stripped);
+		_cache_record_size(full_key, sizes[i]);
 	}
 
 	wq.items = xmalloc(nkeys * sizeof(char *));
@@ -326,6 +476,7 @@ static int _prefetch_current_prefix(int num_workers, char *parent_prefix_out, si
 		for (i = 0; i < nkeys; i++)
 			xfree(keys[i]);
 		free(keys);
+		free(sizes);
 		return -1;
 	}
 	wq.n = 0;
@@ -360,6 +511,8 @@ static int _prefetch_current_prefix(int num_workers, char *parent_prefix_out, si
 		xfree(keys[i]);
 	}
 	free(keys);
+	if (sizes)
+		free(sizes);
 
 	pr_info("prefix '%s': enqueued %zu keys (skipped pages-*/subdirs)\n", current_prefix, wq.n);
 


### PR DESCRIPTION
## Summary

Two metadata-fetch round-trips were costing CRIU restore a full 134ms cross-region RTT every time on the critical path:

1. **`parent-prefix` GET** — page-xfer / pagemap / image.c each issue a `GET(parent-prefix)` at every page_read open to walk pre-dump snapshot chains. For full-dump checkpoints where the marker doesn't exist, this is ENOENT after one full RTT, multiplied by N pagemap files.
2. **HEAD probe in `init_s3_compression`** — reads `pages-*.img` Content-Length to find the zstd-seekable seek table, again ×N pages files.

Both can be answered locally: `obstor_prefetch_init`'s LIST already populated a cache of every key under the active prefix.

## Changes

- LIST XML parser walks `<Contents>` blocks instead of separate `<Key>` / `<Size>` sweeps so we extract size alongside the key.
- `obstor_prefetch_lookup` short-circuits GET. On hit we copy the cached bytes; on authoritative-cache miss we return -ENOENT directly, skipping the cross-region fetch.
- New `obstor_prefetch_lookup_size` does the same for HEAD: the size cache covers every key the LIST wave saw, including `pages-*.img` which isn't otherwise downloaded.
- Lookup keys mirror `_construct_object_url`'s convention: paths with `/` are absolute (e.g. `<prefix>/pages-N.img`), bare names get the active prefix prepended. Without this rule, full-path callers (HEAD) always missed because the cache prepended the prefix a second time.

## Empirical impact

- mc-1gb cross-region (us-west-2 → eu-west-3): restore wall **19.14s → 13.91s** (-27%) just from the GET short-circuit. HEAD short-circuit lands cleanly on top for compressed dumps.
- Same-region effect is in the 0.1–0.3s noise floor — the win is concentrated where RTT × N actually shows up.

## Test plan

- [x] mc-1gb cross-region paired test passing (results-2026-05-06-cross-region-v5.md §3.1)
- [x] All 9 workloads cross-region restore wall measured n=5 (v5 §2.1)
- [x] Same-region restore unchanged (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)