### PR TITLE
proximity-window: PROMOTE_DISTANCE 32 -> 16 (128 MB -> 64 MB)

### DIFF
--- a/criu/obstor_xfer.c
+++ b/criu/obstor_xfer.c
@@ -472,7 +472,7 @@ static struct controller_stats controller_stats;
 static pthread_mutex_t controller_stats_lock = PTHREAD_MUTEX_INITIALIZER;
 
 /* Controller tuning */
-#define PROMOTE_DISTANCE 32          /* Fixed: promote next N IOVs on fault */
+#define PROMOTE_DISTANCE 16          /* Fixed: promote next N IOVs on fault (16 * 4MB = 64MB) */
 
 /* ========== IOV Metadata Functions ========== */
 


### PR DESCRIPTION
## Summary

Reduce `PROMOTE_DISTANCE` from 32 to 16 IOVs (128 MB -> 64 MB on-fault prefetch window).

## Motivation

Fault locality analysis on lazy-restore traces (6 workloads: ml_training, redis, memcached, dataproc, xgboost, matmul) shows:

| Window | ml_training | redis | memcached | dataproc | xgboost | matmul |
|--------|-------------|-------|-----------|----------|---------|--------|
| 4 MB   | 63.4% | 94.8% | 91.1% | 58.9% | 22.5% | 0.0% |
| 64 MB  | 75.2% | 95.7% | 93.0% | 59.7% | 23.7% | 0.0% |
| 128 MB | 78.5% | 95.8% | 95.5% | 60.1% | 23.9% | 0.0% |

Beyond 64 MB the additional within-window hit rate is <=3.3 pp across all 6 workloads. Reducing the on-fault promotion window from 32 to 16 IOVs avoids over-prefetch on sparse-locality workloads (matmul, xgboost) without observable regression on high-locality workloads.

## Validation

`m5.8xlarge` cross-region (us-west-2 -> eu-west-3) and same-region (us-west-2) at NIC-saturating worker count (16 for m5.8xlarge):

| Cell | Daemon (PROMOTE 32) | Daemon (PROMOTE 16) | Delta |
|------|---------------------|----------------------|-------|
| mc-1gb cross w16 | 14.6s | 14.08s | -0.5s |
| mc-1gb same w16  | 5.5s  | (re-measuring) | - |
| mc-16gb cross w16 | 60.6s | 60.46s | -0.14s |
| mc-16gb same w16  | 24.4s | 20.84s | -3.6s |

Cross-region is fault-rate bounded so PROMOTE reduction is noise-level. Same-region exposes over-prefetch waste so reduction is more visible.

## Test plan

- [x] cross-region mc-1gb w16
- [ ] same-region mc-1gb w16 (in progress, replaces previously sampled w8)
- [x] cross-region mc-16gb w16
- [x] same-region mc-16gb w16