### PR TITLE
obstor: bypass authoritative-miss for hot-iovs.json on restore

### DIFF
--- a/criu/include/object-storage.h
+++ b/criu/include/object-storage.h
@@ -203,6 +203,15 @@ void object_storage_drain_uploads(void);
 int object_storage_get_object(const char *object_key, void **out_data, unsigned long *out_length);
 
 /*
+ * Like object_storage_get_object() but bypasses the prefetch-cache
+ * authoritative-miss short-circuit. Use for objects uploaded after CRIU's
+ * manifest is sealed (e.g., hot-iovs.json appended by the workload runner
+ * post-dump), where the manifest cannot mark them as existing. The
+ * cache-hit fast path is still honored.
+ */
+int object_storage_get_object_force(const char *object_key, void **out_data, unsigned long *out_length);
+
+/*
  * HEAD an object: one round-trip to get Content-Length without the body.
  *
  * Used by restore-side compression detection to discover the compressed

--- a/criu/object-storage.c
+++ b/criu/object-storage.c
@@ -3222,7 +3222,7 @@ int object_storage_multipart_abort(const char *object_key, const char *upload_id
  * =================================================================================
  */
 
-int object_storage_get_object(const char *object_key, void **out_data, unsigned long *out_length)
+static int do_get_object(const char *object_key, void **out_data, unsigned long *out_length, bool bypass_cache)
 {
 	struct object_url_info url_info;
 	struct MemoryStruct chunk;
@@ -3250,6 +3250,11 @@ int object_storage_get_object(const char *object_key, void **out_data, unsigned 
 	 * cross-region 404. Most visibly this kills the per-page_read GET of
 	 * "parent-prefix" on full dumps (called from open_page_xfer,
 	 * try_open_parent_at, get_parent_inventory).
+	 *
+	 * bypass_cache=true skips the authoritative-miss short-circuit for
+	 * objects that may be uploaded after CRIU's manifest is sealed (e.g.
+	 * hot-iovs.json appended by the workload runner post-dump). The
+	 * cache-hit fast path is still consulted — if it's cached, we use it.
 	 */
 	if (obstor_prefetch_lookup(object_key, &cache_data, &cache_len) == 0) {
 		void *copy = malloc(cache_len);
@@ -3262,7 +3267,7 @@ int object_storage_get_object(const char *object_key, void **out_data, unsigned 
 			 (unsigned long)cache_len);
 		return 0;
 	}
-	if (obstor_prefetch_is_authoritative()) {
+	if (!bypass_cache && obstor_prefetch_is_authoritative()) {
 		pr_debug("GET %s: skipped (prefetch cache authoritative miss)\n",
 			 object_key);
 		return -ENOENT;
@@ -3328,6 +3333,16 @@ int object_storage_get_object(const char *object_key, void **out_data, unsigned 
 	*out_data = chunk.memory;
 	*out_length = chunk.size;
 	return 0;
+}
+
+int object_storage_get_object(const char *object_key, void **out_data, unsigned long *out_length)
+{
+	return do_get_object(object_key, out_data, out_length, false);
+}
+
+int object_storage_get_object_force(const char *object_key, void **out_data, unsigned long *out_length)
+{
+	return do_get_object(object_key, out_data, out_length, true);
 }
 
 /*

--- a/criu/obstor_xfer.c
+++ b/criu/obstor_xfer.c
@@ -1449,10 +1449,18 @@ static int load_hot_iov_metadata(void)
 		close(fd);
 	}
 
-	/* S3 fallback */
+	/* S3 fallback.
+	 *
+	 * hot-iovs.json is uploaded by the workload runner *after* CRIU writes
+	 * the manifest, so the prefetch cache treats it as an authoritative
+	 * miss. Use the _force variant to bypass that short-circuit and let
+	 * a real S3 GET decide whether the file exists. opts.hot_vma_seed is
+	 * the gate — if seeding is disabled, this function is never called,
+	 * so we don't waste a 404 round-trip on semi-sync/async-only modes.
+	 */
 	if (!data && opts.enable_object_storage) {
 		void *s3_data = NULL;
-		int ret = object_storage_get_object("hot-iovs.json", &s3_data, &data_len);
+		int ret = object_storage_get_object_force("hot-iovs.json", &s3_data, &data_len);
 		if (ret == 0 && s3_data && data_len > 0) {
 			data = xmalloc(data_len + 1);
 			if (data) {


### PR DESCRIPTION
## Summary

`hot-iovs.json` is uploaded by the workload runner (`lib.hot_vma` in the python wrapper) *after* CRIU writes `manifest.txt`. The manifest does not list `hot-iovs.json`. `obstor_prefetch_init` then treats the prefix listing as authoritative, and `object_storage_get_object` short-circuits the `hot-iovs.json` GET with `-ENOENT` before any S3 round-trip — restore falls back to "sequential priority" and the Hot IOV Seed mechanism effectively never runs.

This is visible in the 5/11 restore-perf measurements: every `5_full` run logs:

```
(00.000000)   Hot VMA Seed: enabled
(01.378555) GET hot-iovs.json: skipped (prefetch cache authoritative miss)
(01.378556) prefetch: No hot-iovs.json found, using sequential priority
```

and the JSON records `hot_vma: {available: false}` with `pre_queue.hot = 0`.

## Fix

- New `object_storage_get_object_force()` that honors the prefetch cache *hit* fast path but skips the authoritative-miss short-circuit.
- `load_hot_iov_metadata()` (only called when `opts.hot_vma_seed` is true) uses the force variant.
- Other callers (`parent-prefix`, `MANIFEST_FILE_NAME`, `BUNDLE_FILE_NAME`, generic image fetches) are unchanged — they still get the no-404-roundtrip benefit.

Gate is at the call site in `obstor_xfer.c`:
```c
if (opts.hot_vma_seed)
    load_hot_iov_metadata();
```
so `semi-sync` / `async`-only modes do not pay any extra 404 cost.

## Verification (smoke test on m5.8xlarge, mc-1gb, raw, 5_full)

Before fix (5/11 measurement):
```
hot_vma: {available: false}
pre_queue: hot=0, sequential=...
```

After fix (5/12 smoke test):
```
(02.138821) GET .../hot-iovs.json (full object)
(02.162520) GET hot-iovs.json: 2314 bytes (HTTP 200)
(02.162530) prefetch: Hot IOV range: 0x5593d2aab000 - 0x5593d2ab4000
... (58 hot IOV ranges loaded)
hot_vma: {marked_hot: 58}
pre_queue: hot=44, sequential=233, ...
```

## Test plan
- [x] Build verified (`make -j`, GitID `03dc4916e`).
- [x] Smoke test on m5.8xlarge (mc-1gb, raw, 5_full): hot-iovs.json GET 200, 58 IOVs marked hot, pre-queue receives hot=44 priority entries.
- [ ] Full re-measurement of same-region 9 wl x 5_full and cross-region ours_comp once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)